### PR TITLE
feature: warn when qubit mapping may be lost with add_measurements=False

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -119,6 +119,14 @@ def _check_positional(pos: _T, kw: _T, name: str) -> _T:
     return pos
 
 
+def _has_nontrivial_layout(circuit: QuantumCircuit) -> bool:
+    """Return True if the transpiler assigned a non-identity qubit permutation."""
+    if circuit.layout is None:
+        return False
+    layout = circuit.layout.initial_index_layout(filter_ancillas=False)
+    return layout is not None and layout != list(range(len(layout)))
+
+
 @overload
 def to_braket(
     circuits: _Translatable = ...,
@@ -270,6 +278,18 @@ def to_braket(
         )
         for circ in result.circuits
     ]
+    if not add_measurements and any(_has_nontrivial_layout(c) for c in result.circuits):
+        warnings.warn(
+            "Transpilation with optimization_level > 0 and a coupling_map or target "
+            "may remap qubits. When add_measurements=False the logical-to-physical "
+            "qubit mapping is not reflected by measurement assignments and can be "
+            "hard to recover from the output circuit. "
+            "Consider using add_measurements=True, optimization_level=0, or "
+            "removing the coupling_map (which implicitly assumes a virtual-to-physical "
+            "mapping) if qubit correspondence must be preserved.",
+            UserWarning,
+            stacklevel=2,
+        )
     return translated[0] if single_instance else translated
 
 

--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -1,6 +1,7 @@
 """Tests for Qiskit to Braket adapter."""
 
 import copy
+import warnings
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1627,6 +1628,109 @@ rx(sin(theta) + 2.0*phi) q[0];"""
         expected = QuantumCircuit(1)
         expected.rx(qiskit_theta.sin() + 2.0 * qiskit_phi, 0)
         self.assertEqual(qiskit_circuit, expected)
+
+    def test_qubit_mapping_warning_fires_when_optimization_remaps_qubits(self):
+        """Tests that a UserWarning is issued when optimization_level > 0 and a
+        coupling_map cause qubit remapping with add_measurements=False.
+
+        Without measurements there is no way to recover the logical-to-physical
+        qubit mapping from the Braket circuit output alone. The warning alerts
+        callers before this information is silently lost. Resolves issue #287.
+        """
+
+        qc = QuantumCircuit(6)
+        qc.h(0)
+        qc.h(0)
+        qc.rz(0.1, 1)
+        qc.rz(-0.1, 1)
+        qc.cx(2, 3)
+        qc.cx(3, 4)
+        qc.cx(4, 5)
+
+        cmap = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3], [4, 5], [5, 4]]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            to_braket(
+                qc,
+                add_measurements=False,
+                optimization_level=2,
+                coupling_map=cmap,
+                seed_transpiler=42,
+            )
+
+        mapping_warnings = [x for x in w if "remap" in str(x.message)]
+        self.assertEqual(
+            len(mapping_warnings),
+            1,
+            msg="Expected exactly one UserWarning about qubit remapping when "
+            "optimization_level > 0 and add_measurements=False.",
+        )
+        self.assertIn("add_measurements=True", str(mapping_warnings[0].message))
+
+    def test_no_qubit_mapping_warning_with_measurements(self):
+        """No qubit-remapping warning when add_measurements=True.
+        Resolves issue #287.
+        """
+
+        qc = QuantumCircuit(4)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+        cmap = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2]]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            to_braket(
+                qc,
+                add_measurements=True,
+                optimization_level=2,
+                coupling_map=cmap,
+                seed_transpiler=42,
+            )
+
+        mapping_warnings = [x for x in w if "remap" in str(x.message)]
+        self.assertEqual(len(mapping_warnings), 0)
+
+    def test_no_qubit_mapping_warning_without_coupling_map(self):
+        """No qubit-remapping warning when no coupling_map or target.
+        Resolves issue #287.
+        """
+
+        qc = QuantumCircuit(4)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            to_braket(qc, add_measurements=False, optimization_level=2)
+
+        mapping_warnings = [x for x in w if "remap" in str(x.message)]
+        self.assertEqual(len(mapping_warnings), 0)
+
+    def test_no_qubit_mapping_warning_with_trivial_layout(self):
+        """No qubit-remapping warning when optimization_level=0 (trivial layout).
+        Resolves issue #287.
+        """
+
+        qc = QuantumCircuit(4)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+        cmap = [[0, 1], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2]]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            to_braket(
+                qc,
+                add_measurements=False,
+                optimization_level=0,
+                coupling_map=cmap,
+            )
+
+        mapping_warnings = [x for x in w if "remap" in str(x.message)]
+        self.assertEqual(len(mapping_warnings), 0)
 
     def test_unsupported_parameter_division(self):
         """Tests if TypeError is raised for parameter division."""


### PR DESCRIPTION
Issue #287

**Description of changes:**

When `to_braket` is called with `optimization_level > 0` and a `coupling_map`
(or `target`) and `add_measurements=False`, the Qiskit transpiler remaps virtual
qubits to physical device qubits. If gates cancel during optimization (e.g. H·H
or Rz(x)·Rz(-x)), those qubits disappear from the output entirely. The surviving
gates land on physical qubits chosen by the router — which may not match the
original qubit indices the caller expected. Without measurements there is nothing
in the Braket circuit output to indicate this remapping occurred, so the mapping
is silently lost.

A `UserWarning` is now issued in `to_braket` when `add_measurements=False` and
the transpiler produced a non-trivial qubit permutation (layout ≠ identity). The
message directs users toward `add_measurements=True` or `optimization_level=0`
when qubit correspondence must be preserved.

**Testing done:**

4 new tests in `test/unit_tests/test_adapter.py`:

- `test_qubit_mapping_warning_fires_when_optimization_remaps_qubits` — warning fires with `optimization_level=2` + `coupling_map` + `add_measurements=False`
- `test_no_qubit_mapping_warning_with_measurements` — no warning with `add_measurements=True`
- `test_no_qubit_mapping_warning_without_coupling_map` — no warning without `coupling_map`
- `test_no_qubit_mapping_warning_with_trivial_layout` — no warning with `optimization_level=0`

Full suite: 353 passed, 4 skipped, 0 failures.

---
*Note: AI assistance (Claude) was used during diagnosis.*

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.