### PR TITLE
fix: handle empty if statement

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -425,12 +425,6 @@ class _QiskitProgramContext(AbstractProgramContext):
 
         actual_false = false_body if false_body.data else None
 
-        if not true_body.data and not actual_false:
-            raise ValueError(
-                "Branching statement conditioned on a measurement has empty bodies. "
-                "Both if and else branches contain no quantum operations."
-            )
-
         # Sync parent and both bodies to the same bit layout (IfElseOp requires it).
         self._extend_bits(main, true_body)
         self._extend_bits(main, false_body)

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -149,7 +149,6 @@ if (c[0] == 1) {
 
 
 def test_mcm_branch_empty_bodies():
-    """A branching statement conditioned on MCM with no quantum ops raises ValueError."""
     qasm = """
 OPENQASM 3.0;
 qubit[1] q;
@@ -159,8 +158,12 @@ if (c == 1) {
     int[8] x = 0;
 }
 """
-    with pytest.raises(ValueError, match="empty bodies"):
-        to_qiskit(qasm)
+    qc = to_qiskit(qasm)
+    if_else_ops = _get_if_else_ops(qc)
+    assert len(if_else_ops) == 1
+    true_body, false_body = if_else_ops[0].operation.params
+    assert list(true_body.data) == []
+    assert false_body is None
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/test_adapter_dynamic_circuits.py
+++ b/test/unit_tests/test_adapter_dynamic_circuits.py
@@ -148,15 +148,20 @@ if (c[0] == 1) {
     assert false_body is None
 
 
-def test_mcm_branch_empty_bodies():
-    qasm = """
+@pytest.mark.parametrize(
+    "body",
+    ["int[8] x = 0;", ""],
+    ids=["classical_only", "empty"],
+)
+def test_mcm_branch_empty_bodies(body: str):
+    qasm = f"""
 OPENQASM 3.0;
 qubit[1] q;
 bit c;
 c = measure q[0];
-if (c == 1) {
-    int[8] x = 0;
-}
+if (c == 1) {{
+    {body}
+}}
 """
     qc = to_qiskit(qasm)
     if_else_ops = _get_if_else_ops(qc)


### PR DESCRIPTION
  *Description of changes:*
  Drop the `ValueError` in `_QiskitProgramContext.evaluate_branching_statement` when both branches of an MCM-conditioned `if` have no quantum ops. Such branches are valid OQ3 and now translate to an `IfElseOp` with an empty true body (and `None` false body).
  
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
