### PR TITLE
fix: translate physical qubits through device label mapping

### DIFF
--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -550,7 +550,7 @@ def to_qiskit(
             Qiskit-index order (as ``sorted(topology.nodes)``). When provided, ``$N``
             references in a ``Program`` or ``str`` source resolve to the matching
             Qiskit index; unknown labels raise ``ValueError``. When ``None``, ``$N``
-            maps to Qiskit index ``N`` (legacy). Ignored for ``Circuit`` inputs.
+            maps to Qiskit index ``N``. Ignored for ``Circuit`` inputs.
             Default: ``None``.
 
     Returns:
@@ -578,19 +578,6 @@ def to_qiskit(
 
         >>> qiskit_circuit = to_qiskit(openqasm_program, verbatim_box_name="my_verbatim")
         >>> # All verbatim boxes will have the label "my_verbatim"
-
-        Translate ``$N`` references through a device-specific label mapping:
-
-        >>> # IQM Garnet has 20 qubits labeled 1..20. Passing the labels lets
-        >>> # the top-of-range reference resolve into the 20-qubit target
-        >>> # (Qiskit index 19) instead of overflowing at raw index 20.
-        >>> garnet_labels = tuple(range(1, 21))
-        >>> qc = to_qiskit(
-        ...     Program(source="OPENQASM 3.0;\\nx $20;"),
-        ...     physical_qubit_labels=garnet_labels,
-        ... )
-        >>> qc.num_qubits  # 20, not 21
-        20
     """
     if isinstance(circuit, Program):
         return (

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -537,6 +537,7 @@ def to_qiskit(
     circuit: Circuit | Program | str,
     add_measurements: bool = True,
     verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
+    physical_qubit_labels: Sequence[int] | None = None,
 ) -> QuantumCircuit:
     """Return a Qiskit quantum circuit from a Braket quantum circuit.
 
@@ -545,6 +546,12 @@ def to_qiskit(
         add_measurements (bool): Whether to append measurements in the conversion
         verbatim_box_name (str): Name to use for BoxOp labels when converting verbatim boxes.
             Default: "verbatim"
+        physical_qubit_labels (Sequence[int] | None): Device physical qubit labels in
+            Qiskit-index order (as ``sorted(topology.nodes)``). When provided, ``$N``
+            references in a ``Program`` or ``str`` source resolve to the matching
+            Qiskit index; unknown labels raise ``ValueError``. When ``None``, ``$N``
+            maps to Qiskit index ``N`` (legacy). Ignored for ``Circuit`` inputs.
+            Default: ``None``.
 
     Returns:
         QuantumCircuit: Qiskit quantum circuit
@@ -571,15 +578,32 @@ def to_qiskit(
 
         >>> qiskit_circuit = to_qiskit(openqasm_program, verbatim_box_name="my_verbatim")
         >>> # All verbatim boxes will have the label "my_verbatim"
+
+        Translate ``$N`` references through a device-specific label mapping:
+
+        >>> # IQM Garnet has 20 qubits labeled 1..20. Passing the labels lets
+        >>> # the top-of-range reference resolve into the 20-qubit target
+        >>> # (Qiskit index 19) instead of overflowing at raw index 20.
+        >>> garnet_labels = tuple(range(1, 21))
+        >>> qc = to_qiskit(
+        ...     Program(source="OPENQASM 3.0;\\nx $20;"),
+        ...     physical_qubit_labels=garnet_labels,
+        ... )
+        >>> qc.num_qubits  # 20, not 21
+        20
     """
     if isinstance(circuit, Program):
         return (
-            Interpreter(_QiskitProgramContext(verbatim_box_name))
+            Interpreter(_QiskitProgramContext(verbatim_box_name, physical_qubit_labels))
             .run(circuit.source, inputs=circuit.inputs)
             .circuit
         )
     if isinstance(circuit, str):
-        return Interpreter(_QiskitProgramContext(verbatim_box_name)).run(circuit).circuit
+        return (
+            Interpreter(_QiskitProgramContext(verbatim_box_name, physical_qubit_labels))
+            .run(circuit)
+            .circuit
+        )
     if not isinstance(circuit, Circuit):
         raise TypeError(f"Expected a Circuit, got {type(circuit)} instead.")
 

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -110,12 +110,21 @@ class _QiskitProgramContext(AbstractProgramContext):
 
     num_qubits: int
 
-    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME) -> None:
+    def __init__(
+        self,
+        verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
+        physical_qubit_labels: Sequence[int] | None = None,
+    ) -> None:
         """Initialize the Qiskit program context.
 
         Args:
             verbatim_box_name: Name to use for BoxOp labels when converting verbatim boxes.
                 Default: "verbatim"
+            physical_qubit_labels: Device physical qubit labels in Qiskit-index order
+                (as ``sorted(topology.nodes)``). When provided, ``$N`` references are
+                resolved to the matching Qiskit index and unknown labels raise
+                ``ValueError``. When ``None``, ``$N`` maps directly to Qiskit index
+                ``N`` (legacy). Default: ``None``.
         """
         super().__init__()
         self._circuit_stack: list[QuantumCircuit] = [QuantumCircuit()]
@@ -124,6 +133,44 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
         self._result_types: list[Results] = []
+        self._label_to_qiskit_index: dict[int, int] | None = (
+            {label: i for i, label in enumerate(physical_qubit_labels)}
+            if physical_qubit_labels
+            else None
+        )
+
+    def get_qubits(self, qubits: Identifier | IndexedIdentifier) -> tuple[int, ...]:
+        """Resolve an OpenQASM qubit reference to Qiskit qubit indices.
+
+        Overrides ``AbstractProgramContext.get_qubits`` to translate physical
+        qubit references (``$N``) through ``physical_qubit_labels`` when one
+        was supplied at construction time. Declared register references
+        (``q[i]``) go through the base implementation unchanged.
+
+        Args:
+            qubits: The OpenQASM qubit reference to resolve.
+
+        Returns:
+            tuple[int, ...]: The Qiskit qubit indices the reference targets.
+
+        Raises:
+            ValueError: If ``qubits`` is a ``$N`` reference whose label is not
+                present in the ``physical_qubit_labels`` supplied at
+                construction time.
+        """
+        indices = super().get_qubits(qubits)
+        if self._label_to_qiskit_index is None:
+            return indices
+        # Only a bare Identifier can have a name like "$N"; IndexedIdentifier's
+        # .name is a nested Identifier for the register (e.g. `q`), so its outer
+        # .name attribute is not a str and never starts with "$".
+        name = getattr(qubits, "name", None)
+        if not isinstance(name, str) or not name.startswith("$"):
+            return indices
+        try:
+            return tuple(self._label_to_qiskit_index[label] for label in indices)
+        except KeyError as e:
+            raise ValueError(f"Physical qubit ${e.args[0]} is not on the target device.") from None
 
     @property
     def _active_circuit(self) -> QuantumCircuit:

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -124,7 +124,7 @@ class _QiskitProgramContext(AbstractProgramContext):
                 (as ``sorted(topology.nodes)``). When provided, ``$N`` references are
                 resolved to the matching Qiskit index and unknown labels raise
                 ``ValueError``. When ``None``, ``$N`` maps directly to Qiskit index
-                ``N`` (legacy). Default: ``None``.
+                ``N``. Default: ``None``.
         """
         super().__init__()
         self._circuit_stack: list[QuantumCircuit] = [QuantumCircuit()]
@@ -141,11 +141,6 @@ class _QiskitProgramContext(AbstractProgramContext):
 
     def get_qubits(self, qubits: Identifier | IndexedIdentifier) -> tuple[int, ...]:
         """Resolve an OpenQASM qubit reference to Qiskit qubit indices.
-
-        Overrides ``AbstractProgramContext.get_qubits`` to translate physical
-        qubit references (``$N``) through ``physical_qubit_labels`` when one
-        was supplied at construction time. Declared register references
-        (``q[i]``) go through the base implementation unchanged.
 
         Args:
             qubits: The OpenQASM qubit reference to resolve.

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -13,33 +13,29 @@ from braket.circuits import Circuit
 from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
 
-# IQM Garnet-shaped labels: 20 qubits, 1..20 (1-based, contiguous).
-GARNET_LABELS = tuple(range(1, 21))
-
-# Rigetti Cepheus-shaped labels: 108 qubit slots with qubit 8 missing,
-# so 107 labels with a hole in the middle of the range.
-CEPHEUS_LABELS = tuple(sorted(set(range(108)) - {8}))
+ONE_INDEXED_LABELS = tuple(range(1, 21))
+NONCONTIGUOUS_LABELS = tuple(sorted(set(range(108)) - {8}))
 
 
 @pytest.mark.parametrize(
     "op_line, labels, expected_num_qubits, expected_index",
     [
-        # Bottom and top of a 1-based label range (IQM Garnet shape).
-        ("x $1;", GARNET_LABELS, 1, 0),
-        ("x $20;", GARNET_LABELS, 20, 19),
-        # Example of a hole in the label space (Rigetti Cepheus shape).
-        ("x $9;", CEPHEUS_LABELS, 9, 8),
+        # Bottom and top of a 1-based label range.
+        ("x $1;", ONE_INDEXED_LABELS, 1, 0),
+        ("x $20;", ONE_INDEXED_LABELS, 20, 19),
+        # Reference past a hole in the label space.
+        ("x $9;", NONCONTIGUOUS_LABELS, 9, 8),
         # Top of range on a device with a hole in the middle.
-        ("x $107;", CEPHEUS_LABELS, 107, 106),
+        ("x $107;", NONCONTIGUOUS_LABELS, 107, 106),
         # A $N measurement-only reference is translated the same way.
-        ("bit[1] b;\nb[0] = measure $20;", GARNET_LABELS, 20, 19),
+        ("bit[1] b;\nb[0] = measure $20;", ONE_INDEXED_LABELS, 20, 19),
     ],
     ids=[
-        "garnet_$1_bottom",
-        "garnet_$20_top",
-        "cepheus_$9_after_hole",
-        "cepheus_$107_top",
-        "garnet_measure_$20",
+        "one_indexed_$1_bottom",
+        "one_indexed_$20_top",
+        "noncontiguous_$9_after_hole",
+        "noncontiguous_$107_top",
+        "one_indexed_measure_$20",
     ],
 )
 def test_physical_qubit_reference_translated(
@@ -56,7 +52,7 @@ def test_physical_qubit_reference_translated(
 def test_two_qubit_gate_across_range():
     qc = to_qiskit(
         Program(source="OPENQASM 3.0;\ncz $1, $20;"),
-        physical_qubit_labels=GARNET_LABELS,
+        physical_qubit_labels=ONE_INDEXED_LABELS,
     )
     assert qc.num_qubits == 20
     cz_qubits = qc.data[0].qubits
@@ -66,11 +62,11 @@ def test_two_qubit_gate_across_range():
 @pytest.mark.parametrize(
     "bad_label, labels",
     [
-        (8, CEPHEUS_LABELS),  # Hole in the middle of the label space.
-        (0, GARNET_LABELS),  # Below a 1-based range.
-        (21, GARNET_LABELS),  # Above the range.
+        (8, NONCONTIGUOUS_LABELS),  # Hole in the middle of the label space.
+        (0, ONE_INDEXED_LABELS),  # Below a 1-based range.
+        (21, ONE_INDEXED_LABELS),  # Above the range.
     ],
-    ids=["cepheus_hole", "garnet_below_range", "garnet_above_range"],
+    ids=["hole_in_labels", "below_range", "above_range"],
 )
 def test_out_of_range_label_raises(bad_label: int, labels: tuple[int, ...]):
     with pytest.raises(ValueError, match=rf"\${bad_label} is not on"):
@@ -83,7 +79,7 @@ def test_out_of_range_label_raises(bad_label: int, labels: tuple[int, ...]):
 def test_declared_register_not_translated():
     qc = to_qiskit(
         Program(source="OPENQASM 3.0;\nqubit[3] q;\nx q[0];"),
-        physical_qubit_labels=GARNET_LABELS,
+        physical_qubit_labels=ONE_INDEXED_LABELS,
     )
     assert qc.num_qubits == 3
     assert len(qc.qregs) == 1 and qc.qregs[0].size == 3
@@ -93,7 +89,7 @@ def test_declared_register_not_translated():
 def test_physical_qubit_inside_verbatim_box_translated():
     qc = to_qiskit(
         Program(source=("OPENQASM 3.0;\n#pragma braket verbatim\nbox { x $20; }\n")),
-        physical_qubit_labels=GARNET_LABELS,
+        physical_qubit_labels=ONE_INDEXED_LABELS,
     )
     assert qc.num_qubits == 20
     box_op = qc.data[0].operation
@@ -121,14 +117,14 @@ def test_no_labels_or_empty_labels_preserves_legacy_behavior(labels: tuple[int, 
 )
 def test_program_and_str_sources_both_translated(make_input: Callable[[str], Program | str]):
     source = "OPENQASM 3.0;\nx $20;"
-    qc = to_qiskit(make_input(source), physical_qubit_labels=GARNET_LABELS)
+    qc = to_qiskit(make_input(source), physical_qubit_labels=ONE_INDEXED_LABELS)
     assert qc.num_qubits == 20
     assert qc.find_bit(qc.data[0].qubits[0]).index == 19
 
 
 def test_circuit_input_ignores_labels():
     circuit = Circuit().x(0)
-    with_labels = to_qiskit(circuit, physical_qubit_labels=GARNET_LABELS)
+    with_labels = to_qiskit(circuit, physical_qubit_labels=ONE_INDEXED_LABELS)
     without = to_qiskit(circuit)
     assert with_labels.num_qubits == without.num_qubits
     assert [i.operation.name for i in with_labels.data] == [i.operation.name for i in without.data]

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -1,0 +1,134 @@
+"""Tests for the physical_qubit_labels translation in to_qiskit.
+
+Covers _QiskitProgramContext.get_qubits() with physical_qubit_labels supplied:
+$N references are translated through the label map, unknown labels raise
+ValueError, declared registers and Circuit inputs are unaffected.
+"""
+
+from collections.abc import Callable
+
+import pytest
+
+from braket.circuits import Circuit
+from braket.ir.openqasm import Program
+from qiskit_braket_provider import to_qiskit
+
+# IQM Garnet-shaped labels: 20 qubits, 1..20 (1-based, contiguous).
+GARNET_LABELS = tuple(range(1, 21))
+
+# Rigetti Cepheus-shaped labels: 108 qubit slots with qubit 8 missing,
+# so 107 labels with a hole in the middle of the range.
+CEPHEUS_LABELS = tuple(sorted(set(range(108)) - {8}))
+
+
+@pytest.mark.parametrize(
+    "op_line, labels, expected_num_qubits, expected_index",
+    [
+        # Bottom and top of a 1-based label range (IQM Garnet shape).
+        ("x $1;", GARNET_LABELS, 1, 0),
+        ("x $20;", GARNET_LABELS, 20, 19),
+        # Example of a hole in the label space (Rigetti Cepheus shape).
+        ("x $9;", CEPHEUS_LABELS, 9, 8),
+        # Top of range on a device with a hole in the middle.
+        ("x $107;", CEPHEUS_LABELS, 107, 106),
+        # A $N measurement-only reference is translated the same way.
+        ("bit[1] b;\nb[0] = measure $20;", GARNET_LABELS, 20, 19),
+    ],
+    ids=[
+        "garnet_$1_bottom",
+        "garnet_$20_top",
+        "cepheus_$9_after_hole",
+        "cepheus_$107_top",
+        "garnet_measure_$20",
+    ],
+)
+def test_physical_qubit_reference_translated(
+    op_line: str, labels: tuple[int, ...], expected_num_qubits: int, expected_index: int
+):
+    qc = to_qiskit(
+        Program(source=f"OPENQASM 3.0;\n{op_line}"),
+        physical_qubit_labels=labels,
+    )
+    assert qc.num_qubits == expected_num_qubits
+    assert qc.find_bit(qc.data[0].qubits[0]).index == expected_index
+
+
+def test_two_qubit_gate_across_range():
+    qc = to_qiskit(
+        Program(source="OPENQASM 3.0;\ncz $1, $20;"),
+        physical_qubit_labels=GARNET_LABELS,
+    )
+    assert qc.num_qubits == 20
+    cz_qubits = qc.data[0].qubits
+    assert tuple(qc.find_bit(q).index for q in cz_qubits) == (0, 19)
+
+
+@pytest.mark.parametrize(
+    "bad_label, labels",
+    [
+        (8, CEPHEUS_LABELS),  # Hole in the middle of the label space.
+        (0, GARNET_LABELS),  # Below a 1-based range.
+        (21, GARNET_LABELS),  # Above the range.
+    ],
+    ids=["cepheus_hole", "garnet_below_range", "garnet_above_range"],
+)
+def test_out_of_range_label_raises(bad_label: int, labels: tuple[int, ...]):
+    with pytest.raises(ValueError, match=rf"\${bad_label} is not on"):
+        to_qiskit(
+            Program(source=f"OPENQASM 3.0;\nx ${bad_label};"),
+            physical_qubit_labels=labels,
+        )
+
+
+def test_declared_register_not_translated():
+    qc = to_qiskit(
+        Program(source="OPENQASM 3.0;\nqubit[3] q;\nx q[0];"),
+        physical_qubit_labels=GARNET_LABELS,
+    )
+    assert qc.num_qubits == 3
+    assert len(qc.qregs) == 1 and qc.qregs[0].size == 3
+    assert qc.find_bit(qc.data[0].qubits[0]).index == 0
+
+
+def test_physical_qubit_inside_verbatim_box_translated():
+    qc = to_qiskit(
+        Program(source=("OPENQASM 3.0;\n#pragma braket verbatim\nbox { x $20; }\n")),
+        physical_qubit_labels=GARNET_LABELS,
+    )
+    assert qc.num_qubits == 20
+    box_op = qc.data[0].operation
+    assert box_op.name == "box"
+    body = box_op.body
+    assert body.find_bit(body.data[0].qubits[0]).index == 19
+
+
+@pytest.mark.parametrize("labels", [None, ()], ids=["none", "empty_tuple"])
+def test_no_labels_or_empty_labels_preserves_legacy_behavior(labels: tuple[int, ...] | None):
+    qc = to_qiskit(
+        Program(source="OPENQASM 3.0;\nx $20;"),
+        physical_qubit_labels=labels,
+    )
+    assert qc.num_qubits == 21
+    assert qc.find_bit(qc.data[0].qubits[0]).index == 20
+
+
+@pytest.mark.parametrize(
+    "make_input",
+    [
+        pytest.param(lambda src: Program(source=src), id="Program"),
+        pytest.param(lambda src: src, id="str"),
+    ],
+)
+def test_program_and_str_sources_both_translated(make_input: Callable[[str], Program | str]):
+    source = "OPENQASM 3.0;\nx $20;"
+    qc = to_qiskit(make_input(source), physical_qubit_labels=GARNET_LABELS)
+    assert qc.num_qubits == 20
+    assert qc.find_bit(qc.data[0].qubits[0]).index == 19
+
+
+def test_circuit_input_ignores_labels():
+    circuit = Circuit().x(0)
+    with_labels = to_qiskit(circuit, physical_qubit_labels=GARNET_LABELS)
+    without = to_qiskit(circuit)
+    assert with_labels.num_qubits == without.num_qubits
+    assert [i.operation.name for i in with_labels.data] == [i.operation.name for i in without.data]


### PR DESCRIPTION
Adds an optional physical_qubit_labels parameter to to_qiskit() and _QiskitProgramContext. When provided, $N references in an OpenQASM source resolve to the Qiskit qubit index of that label in sorted(topology.nodes) order, instead of being placed at raw index N.

Without this mapping, $N inflates qiskit_circuit.num_qubits to N+1 via _ensure_qubit_capacity, causing compilation to fail with TrivialLayout's 'Number of qubits greater than device.' error on devices whose label space starts above 0 or has holes:

Unknown labels now raise ValueError at parse time (previously a downstream TranspilerError with a less actionable message).

Declared registers (qubit[N] q; q[i]) and Braket Circuit inputs are unaffected. Default is None, which preserves the legacy behavior of mapping $N directly to Qiskit index N.

Tests: 16 parametrized cases in
test_adapter_to_qiskit_physical_qubit_labels.py covering Garnet and Cepheus shapes, out-of-range labels, declared registers, verbatim boxes, both Program and str sources, Circuit input pass-through, and legacy behavior for None and empty labels.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
