### PR TITLE
fix: pragma physical qubit labels

### DIFF
--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -8,7 +8,7 @@ mid-circuit measurement.
 from collections.abc import Iterator, Sequence
 from math import prod
 from numbers import Number
-from typing import Any
+from typing import Any, cast
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import (
@@ -55,6 +55,7 @@ from braket.default_simulator.openqasm.parser.openqasm_ast import (
 )
 from braket.default_simulator.openqasm.program_context import (
     AbstractProgramContext,
+    QubitTable,
 )
 from braket.ir.jaqcd import AdjointGradient
 from braket.ir.jaqcd.program_v1 import Results
@@ -96,6 +97,43 @@ def _sympy_to_qiskit(
     raise TypeError(f"unrecognized parameter type in conversion: {type(expr)}")
 
 
+class _LabelMappedQubitTable(QubitTable):
+    """QubitTable that translates ``$N`` references through a device label map.
+
+    ``$N`` references resolve to the Qiskit qubit index of Braket label ``N`` in
+    the caller's ``physical_qubit_labels`` (sorted-topology order) rather than
+    to raw index ``N``. Declared register lookups (``q[i]``) go through the
+    base implementation unchanged.
+
+    Placed on ``AbstractProgramContext.qubit_mapping`` so both gate-op
+    resolution (via ``AbstractProgramContext.get_qubits``) and pragma parsing
+    (via ``parse_braket_pragma(body, qubit_mapping)``) share one translation
+    point.
+    """
+
+    def __init__(self, label_to_qiskit_index: dict[int, int] | None = None) -> None:
+        super().__init__()
+        self._label_to_qiskit_index = label_to_qiskit_index
+
+    def get_by_identifier(self, identifier: Identifier | IndexedIdentifier) -> tuple[int]:
+        indices = super().get_by_identifier(identifier)
+        if self._label_to_qiskit_index is None:
+            return indices
+        # $N references arrive as a bare Identifier whose name starts with "$".
+        # IndexedIdentifier (register access) has a nested Identifier for .name
+        # so its .name attribute is not a str.
+        name = getattr(identifier, "name", None)
+        if not isinstance(name, str) or not name.startswith("$"):
+            return indices
+        try:
+            return cast(
+                "tuple[int]",
+                tuple(self._label_to_qiskit_index[label] for label in indices),
+            )
+        except KeyError as e:
+            raise ValueError(f"Physical qubit ${e.args[0]} is not on the target device.") from None
+
+
 class _QiskitProgramContext(AbstractProgramContext):
     """Program context for converting OpenQASM 3 programs to Qiskit circuits.
 
@@ -133,39 +171,17 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
         self._result_types: list[Results] = []
-        self._label_to_qiskit_index: dict[int, int] | None = (
+        # Build a reverse label map and install a QubitTable subclass that
+        # translates $N references through it. Placing the translation on
+        # self.qubit_mapping (rather than overriding get_qubits) covers both
+        # gate-op resolution and parse_braket_pragma, which receive the same
+        # QubitTable instance.
+        label_to_qiskit_index: dict[int, int] | None = (
             {label: i for i, label in enumerate(physical_qubit_labels)}
             if physical_qubit_labels
             else None
         )
-
-    def get_qubits(self, qubits: Identifier | IndexedIdentifier) -> tuple[int, ...]:
-        """Resolve an OpenQASM qubit reference to Qiskit qubit indices.
-
-        Args:
-            qubits: The OpenQASM qubit reference to resolve.
-
-        Returns:
-            tuple[int, ...]: The Qiskit qubit indices the reference targets.
-
-        Raises:
-            ValueError: If ``qubits`` is a ``$N`` reference whose label is not
-                present in the ``physical_qubit_labels`` supplied at
-                construction time.
-        """
-        indices = super().get_qubits(qubits)
-        if self._label_to_qiskit_index is None:
-            return indices
-        # Only a bare Identifier can have a name like "$N"; IndexedIdentifier's
-        # .name is a nested Identifier for the register (e.g. `q`), so its outer
-        # .name attribute is not a str and never starts with "$".
-        name = getattr(qubits, "name", None)
-        if not isinstance(name, str) or not name.startswith("$"):
-            return indices
-        try:
-            return tuple(self._label_to_qiskit_index[label] for label in indices)
-        except KeyError as e:
-            raise ValueError(f"Physical qubit ${e.args[0]} is not on the target device.") from None
+        self.qubit_mapping = _LabelMappedQubitTable(label_to_qiskit_index)
 
     @property
     def _active_circuit(self) -> QuantumCircuit:
@@ -199,6 +215,20 @@ class _QiskitProgramContext(AbstractProgramContext):
             raise NotImplementedError(
                 "AdjointGradient result type is not supported in the Qiskit compilation pipeline."
             )
+        # parse_braket_pragma resolves multi-target references through
+        # qubit_table.get_by_identifier (which our _LabelMappedQubitTable covers)
+        # but visitGateOperand short-circuits $N observable targets and returns
+        # the raw label. Rewrite result.targets through the same label map so
+        # downstream passes (AddBasisRotationAndMeasurement) can index the
+        # compact Qiskit circuit correctly.
+        label_to_qiskit_index = getattr(self.qubit_mapping, "_label_to_qiskit_index", None)
+        if label_to_qiskit_index is not None and getattr(result, "targets", None):
+            try:
+                result.targets = [label_to_qiskit_index[label] for label in result.targets]
+            except KeyError as e:
+                raise ValueError(
+                    f"Physical qubit ${e.args[0]} is not on the target device."
+                ) from None
         self._result_types.append(result)
         qc = self._circuit_stack[0]
         qc.metadata["braket_result_pragmas"] = self._result_types

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -8,7 +8,7 @@ mid-circuit measurement.
 from collections.abc import Iterator, Sequence
 from math import prod
 from numbers import Number
-from typing import Any, cast
+from typing import Any
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import (
@@ -98,38 +98,20 @@ def _sympy_to_qiskit(
 
 
 class _LabelMappedQubitTable(QubitTable):
-    """QubitTable that translates ``$N`` references through a device label map.
-
-    ``$N`` references resolve to the Qiskit qubit index of Braket label ``N`` in
-    the caller's ``physical_qubit_labels`` (sorted-topology order) rather than
-    to raw index ``N``. Declared register lookups (``q[i]``) go through the
-    base implementation unchanged.
-
-    Placed on ``AbstractProgramContext.qubit_mapping`` so both gate-op
-    resolution (via ``AbstractProgramContext.get_qubits``) and pragma parsing
-    (via ``parse_braket_pragma(body, qubit_mapping)``) share one translation
-    point.
-    """
+    """QubitTable that translates ``$N`` references through a device label map."""
 
     def __init__(self, label_to_qiskit_index: dict[int, int] | None = None) -> None:
         super().__init__()
         self._label_to_qiskit_index = label_to_qiskit_index
 
-    def get_by_identifier(self, identifier: Identifier | IndexedIdentifier) -> tuple[int]:
+    def get_by_identifier(self, identifier: Identifier | IndexedIdentifier) -> tuple[int, ...]:
         indices = super().get_by_identifier(identifier)
         if self._label_to_qiskit_index is None:
             return indices
-        # $N references arrive as a bare Identifier whose name starts with "$".
-        # IndexedIdentifier (register access) has a nested Identifier for .name
-        # so its .name attribute is not a str.
-        name = getattr(identifier, "name", None)
-        if not isinstance(name, str) or not name.startswith("$"):
+        if not isinstance(identifier, Identifier) or not identifier.name.startswith("$"):
             return indices
         try:
-            return cast(
-                "tuple[int]",
-                tuple(self._label_to_qiskit_index[label] for label in indices),
-            )
+            return tuple(self._label_to_qiskit_index[label] for label in indices)
         except KeyError as e:
             raise ValueError(f"Physical qubit ${e.args[0]} is not on the target device.") from None
 

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -171,11 +171,6 @@ class _QiskitProgramContext(AbstractProgramContext):
         self._verbatim_box_name = verbatim_box_name
         self._clbit_offset: dict[str, int] = {}
         self._result_types: list[Results] = []
-        # Build a reverse label map and install a QubitTable subclass that
-        # translates $N references through it. Placing the translation on
-        # self.qubit_mapping (rather than overriding get_qubits) covers both
-        # gate-op resolution and parse_braket_pragma, which receive the same
-        # QubitTable instance.
         label_to_qiskit_index: dict[int, int] | None = (
             {label: i for i, label in enumerate(physical_qubit_labels)}
             if physical_qubit_labels
@@ -216,11 +211,10 @@ class _QiskitProgramContext(AbstractProgramContext):
                 "AdjointGradient result type is not supported in the Qiskit compilation pipeline."
             )
         # parse_braket_pragma resolves multi-target references through
-        # qubit_table.get_by_identifier (which our _LabelMappedQubitTable covers)
-        # but visitGateOperand short-circuits $N observable targets and returns
-        # the raw label. Rewrite result.targets through the same label map so
-        # downstream passes (AddBasisRotationAndMeasurement) can index the
-        # compact Qiskit circuit correctly.
+        # qubit_table.get_by_identifier but visitGateOperand short-circuits
+        # $N observable targets and returns the raw label. Rewrite result.targets
+        # through the same label map so downstream passes (AddBasisRotationAndMeasurement)
+        # can index the compact Qiskit circuit correctly.
         label_to_qiskit_index = getattr(self.qubit_mapping, "_label_to_qiskit_index", None)
         if label_to_qiskit_index is not None and getattr(result, "targets", None):
             try:

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -210,19 +210,6 @@ class _QiskitProgramContext(AbstractProgramContext):
             raise NotImplementedError(
                 "AdjointGradient result type is not supported in the Qiskit compilation pipeline."
             )
-        # parse_braket_pragma resolves multi-target references through
-        # qubit_table.get_by_identifier but visitGateOperand short-circuits
-        # $N observable targets and returns the raw label. Rewrite result.targets
-        # through the same label map so downstream passes (AddBasisRotationAndMeasurement)
-        # can index the compact Qiskit circuit correctly.
-        label_to_qiskit_index = getattr(self.qubit_mapping, "_label_to_qiskit_index", None)
-        if label_to_qiskit_index is not None and getattr(result, "targets", None):
-            try:
-                result.targets = [label_to_qiskit_index[label] for label in result.targets]
-            except KeyError as e:
-                raise ValueError(
-                    f"Physical qubit ${e.args[0]} is not on the target device."
-                ) from None
         self._result_types.append(result)
         qc = self._circuit_stack[0]
         qc.metadata["braket_result_pragmas"] = self._result_types

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=2021.5.30
 qiskit>=2.0.0,<3.0.0
 qiskit-ionq>=1.0.0,<2.0.0
 amazon-braket-sdk>=1.123.0
-amazon-braket-default-simulator>=1.40.0
+amazon-braket-default-simulator>=1.40.1
 
 setuptools>=40.1.0
 numpy>=1.23

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -138,6 +138,11 @@ def test_circuit_input_ignores_labels():
         pytest.param("variance y($10)", [9], id="variance"),
         pytest.param("probability $1, $20", [0, 19], id="multi_target_probability"),
         pytest.param("density_matrix $1, $2", [0, 1], id="multi_target_density_matrix"),
+        pytest.param(
+            "expectation hermitian([[0+0im, 1+0im], [1+0im, 0+0im]]) $6",
+            [5],
+            id="hermitian_observable",
+        ),
     ],
 )
 def test_pragma_targets_translated_through_labels(pragma_body: str, expected_targets: list[int]):
@@ -149,6 +154,39 @@ def test_pragma_targets_translated_through_labels(pragma_body: str, expected_tar
     pragmas = qc.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
     assert pragmas[0].targets == expected_targets
+
+
+@pytest.mark.parametrize(
+    ("pragma_body", "expected_targets"),
+    [
+        pytest.param("expectation z($9)", [8], id="standard_observable_after_hole"),
+        pytest.param("probability $0, $9", [0, 8], id="multi_target_around_hole"),
+        pytest.param("sample x($107)", [106], id="top_of_range"),
+    ],
+)
+def test_pragma_targets_translated_through_noncontiguous_labels(
+    pragma_body: str, expected_targets: list[int]
+):
+    source = (
+        "OPENQASM 3.0;\nbit[1] b;\nx $0;\nb[0] = measure $0;\n"
+        f"#pragma braket result {pragma_body}\n"
+    )
+    qc = to_qiskit(Program(source=source), physical_qubit_labels=NONCONTIGUOUS_LABELS)
+    pragmas = qc.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    assert pragmas[0].targets == expected_targets
+
+
+def test_pragma_declared_register_targets_not_translated():
+    source = (
+        "OPENQASM 3.0;\nqubit[2] q;\nbit[2] b;\nh q[0];\ncnot q[0], q[1];\n"
+        "b[0] = measure q[0];\nb[1] = measure q[1];\n"
+        "#pragma braket result probability q[0], q[1]\n"
+    )
+    qc = to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)
+    pragmas = qc.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    assert pragmas[0].targets == [0, 1]
 
 
 def test_pragma_target_off_device_raises():

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -130,21 +130,41 @@ def test_circuit_input_ignores_labels():
     assert [i.operation.name for i in with_labels.data] == [i.operation.name for i in without.data]
 
 
-def test_pragma_target_translated_through_labels():
+@pytest.mark.parametrize(
+    ("pragma_body", "expected_targets"),
+    [
+        pytest.param("expectation z($20)", [19], id="standard_observable"),
+        pytest.param("sample x($1) @ x($20)", [0, 19], id="tensor_product_observable"),
+        pytest.param("variance y($10)", [9], id="variance"),
+        pytest.param("probability $1, $20", [0, 19], id="multi_target_probability"),
+        pytest.param("density_matrix $1, $2", [0, 1], id="multi_target_density_matrix"),
+    ],
+)
+def test_pragma_targets_translated_through_labels(pragma_body: str, expected_targets: list[int]):
     source = (
-        "OPENQASM 3.0;\nbit[1] b;\nx $20;\nb[0] = measure $20;\n"
-        "#pragma braket result expectation z($20)\n"
+        "OPENQASM 3.0;\nbit[1] b;\nx $1;\nb[0] = measure $1;\n"
+        f"#pragma braket result {pragma_body}\n"
     )
     qc = to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)
     pragmas = qc.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
-    # The pragma target should hold the Qiskit qubit index (19), not the raw
-    # Braket label (20). AddBasisRotationAndMeasurement dereferences the value
-    # via dag.qubits[target] on the compact circuit.
-    assert pragmas[0].targets == [19]
+    assert pragmas[0].targets == expected_targets
 
 
 def test_pragma_target_off_device_raises():
-    source = "OPENQASM 3.0;\nbit[1] b;\nx $1;\nb[0] = measure $1;\n#pragma braket result expectation z($21)\n"
+    source = (
+        "OPENQASM 3.0;\nbit[1] b;\nx $1;\nb[0] = measure $1;\n"
+        "#pragma braket result expectation z($21)\n"
+    )
     with pytest.raises(ValueError, match=r"\$21 is not on"):
         to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)
+
+
+def test_pragma_targets_legacy_no_labels():
+    source = (
+        "OPENQASM 3.0;\nbit[1] b;\nx $0;\nb[0] = measure $0;\n"
+        "#pragma braket result expectation z($0)\n"
+    )
+    qc = to_qiskit(Program(source=source))
+    pragmas = qc.metadata["braket_result_pragmas"]
+    assert pragmas[0].targets == [0]

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -142,3 +142,9 @@ def test_pragma_target_translated_through_labels():
     # Braket label (20). AddBasisRotationAndMeasurement dereferences the value
     # via dag.qubits[target] on the compact circuit.
     assert pragmas[0].targets == [19]
+
+
+def test_pragma_target_off_device_raises():
+    source = "OPENQASM 3.0;\nbit[1] b;\nx $1;\nb[0] = measure $1;\n#pragma braket result expectation z($21)\n"
+    with pytest.raises(ValueError, match=r"\$21 is not on"):
+        to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -177,16 +177,28 @@ def test_pragma_targets_translated_through_noncontiguous_labels(
     assert pragmas[0].targets == expected_targets
 
 
-def test_pragma_declared_register_targets_not_translated():
+@pytest.mark.parametrize(
+    ("pragma_body", "expected_targets"),
+    [
+        pytest.param("probability q[0], q[1]", [0, 1], id="indexed_register"),
+        pytest.param("probability q", [0, 1], id="bare_register_broadcast"),
+    ],
+)
+def test_pragma_declared_register_targets_not_translated(
+    pragma_body: str, expected_targets: list[int]
+):
+    # Register references (q[i] and bare q) go through the base QubitTable
+    # path — the label map only applies to $N references. Targets must resolve
+    # unchanged even with physical_qubit_labels set.
     source = (
-        "OPENQASM 3.0;\nqubit[2] q;\nbit[2] b;\nh q[0];\ncnot q[0], q[1];\n"
+        "OPENQASM 3.0;\nqubit[2] q;\nbit[2] b;\n"
         "b[0] = measure q[0];\nb[1] = measure q[1];\n"
-        "#pragma braket result probability q[0], q[1]\n"
+        f"#pragma braket result {pragma_body}\n"
     )
     qc = to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)
     pragmas = qc.metadata["braket_result_pragmas"]
     assert len(pragmas) == 1
-    assert pragmas[0].targets == [0, 1]
+    assert pragmas[0].targets == expected_targets
 
 
 def test_pragma_target_off_device_raises():

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -131,10 +131,6 @@ def test_circuit_input_ignores_labels():
 
 
 def test_pragma_target_translated_through_labels():
-    # Pragma parsing goes through qubit_mapping.get_by_identifier directly (not
-    # through _QiskitProgramContext.get_qubits), so putting the translation on
-    # the QubitTable is what makes result pragmas store Qiskit indices, not raw
-    # Braket labels.
     source = (
         "OPENQASM 3.0;\nbit[1] b;\nx $20;\nb[0] = measure $20;\n"
         "#pragma braket result expectation z($20)\n"

--- a/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
+++ b/test/unit_tests/test_adapter_to_qiskit_physical_qubit_labels.py
@@ -128,3 +128,21 @@ def test_circuit_input_ignores_labels():
     without = to_qiskit(circuit)
     assert with_labels.num_qubits == without.num_qubits
     assert [i.operation.name for i in with_labels.data] == [i.operation.name for i in without.data]
+
+
+def test_pragma_target_translated_through_labels():
+    # Pragma parsing goes through qubit_mapping.get_by_identifier directly (not
+    # through _QiskitProgramContext.get_qubits), so putting the translation on
+    # the QubitTable is what makes result pragmas store Qiskit indices, not raw
+    # Braket labels.
+    source = (
+        "OPENQASM 3.0;\nbit[1] b;\nx $20;\nb[0] = measure $20;\n"
+        "#pragma braket result expectation z($20)\n"
+    )
+    qc = to_qiskit(Program(source=source), physical_qubit_labels=ONE_INDEXED_LABELS)
+    pragmas = qc.metadata["braket_result_pragmas"]
+    assert len(pragmas) == 1
+    # The pragma target should hold the Qiskit qubit index (19), not the raw
+    # Braket label (20). AddBasisRotationAndMeasurement dereferences the value
+    # via dag.qubits[target] on the compact circuit.
+    assert pragmas[0].targets == [19]


### PR DESCRIPTION
fix: apply physical_qubit_labels to pragma targets
  
  Follow-up to #383. The 0.23.1 fix translated $N in gate operations but missed pragma targets — those go through a different resolution path that bypassed the _QiskitProgramContext.get_qubits override.
  
  The two gaps:
  
  - parse_braket_pragma resolves $N for MultiTarget references directly via qubit_table.get_by_identifier(...), bypassing the context's get_qubits.
  - visitGateOperand short-circuits HardwareQubit ($N) observable targets with an inline text hack (int(text[1:])), never consulting the qubit table at all.
  
  Both left pragma targets as raw Braket labels in qc.metadata["braket_result_pragmas"]. Downstream, AddBasisRotationAndMeasurement dereferenced dag.qubits[label] against the compact Qiskit circuit and hit IndexError on any 1-based-labeled device (IQM Garnet, Emerald).
  
  What this PR does:
  
  - Adds _LabelMappedQubitTable, a QubitTable subclass that translates $N → Qiskit index inside get_by_identifier. Installed on _QiskitProgramContext.qubit_mapping, so both gate-op resolution and pragma MultiTarget resolution use one code path.
  - Removes the now-redundant _QiskitProgramContext.get_qubits override.
  - Translates result.targets inside _QiskitProgramContext.add_result to cover the visitGateOperand short-circuit for observable targets.
  
  Test: test_pragma_target_translated_through_labels asserts pragmas store Qiskit indices ([19]), not raw Braket labels ([20]), for expectation z($20) on Garnet-shape labels.
  
  Follow-up idea (separate): fix visitGateOperand in amazon-braket-default-simulator to route $N through qubit_table.get_by_identifier, which would let us drop the add_result translation here.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
