### PR TITLE
feat: add compile_to_oq3() output path

### DIFF
--- a/qiskit_braket_provider/providers/__init__.py
+++ b/qiskit_braket_provider/providers/__init__.py
@@ -20,11 +20,15 @@ Provider classes and functions
     BraketProvider
     BraketQuantumTask
     BraketSampler
+    compile_to_oq3
     to_braket
+    to_oq3
     to_qiskit
 """
 
+from .adapter import compile_to_oq3 as compile_to_oq3
 from .adapter import to_braket as to_braket
+from .adapter import to_oq3 as to_oq3
 from .adapter import to_qiskit as to_qiskit
 from .braket_backend import AWSBraketBackend as AWSBraketBackend
 from .braket_backend import BraketAwsBackend as BraketAwsBackend

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,6 +9,7 @@ sequences that should not be optimized.
 import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from typing import Any, TypeAlias, TypeVar, overload
+
 import numpy as np
 import qiskit.circuit.library as qiskit_gates
 import qiskit.quantum_info as qiskit_qi
@@ -54,14 +55,14 @@ from qiskit_braket_provider.providers.gate_mappings import (
     _QISKIT_TO_BRAKET_OQ3_NAMES,
     _reverse_endianness,
 )
-from qiskit_braket_provider.providers.qasm_context import (
-    _QiskitProgramContext,
-    _sympy_to_qiskit,
-)
 from qiskit_braket_provider.providers.oq3_utils import _post_process_oq3
 from qiskit_braket_provider.providers.passes import (
     ConsolidateClbits,
     WrapInVerbatimBox,
+)
+from qiskit_braket_provider.providers.qasm_context import (
+    _QiskitProgramContext,
+    _sympy_to_qiskit,
 )
 from qiskit_braket_provider.providers.target import (
     _get_controlled_gateset,  # ruff:ignore[unused-import]
@@ -823,13 +824,13 @@ def compile_to_oq3(
 
 
 @overload
-def compile_to_oq3(
+def compile_to_oq3(  # type: ignore[misc]
     circuits: Iterable[QuantumCircuit],
     **kwargs,
 ) -> list[str]: ...
 
 
-def compile_to_oq3(
+def compile_to_oq3(  # type: ignore[misc]
     circuits: QuantumCircuit | Iterable[QuantumCircuit],
     *,
     qubit_labels: Sequence[int] | None = None,
@@ -904,10 +905,7 @@ def compile_to_oq3(
     )
 
     should_wrap_verbatim = (
-        verbatim
-        or pass_manager is not None
-        or target is not None
-        or braket_device is not None
+        verbatim or pass_manager is not None or target is not None or braket_device is not None
     )
     effective_basis_gates = result.basis_gates
     if effective_basis_gates is None and result.target is not None:

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -9,11 +9,10 @@ sequences that should not be optimized.
 import warnings
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from typing import Any, TypeAlias, TypeVar, overload
-
 import numpy as np
 import qiskit.circuit.library as qiskit_gates
 import qiskit.quantum_info as qiskit_qi
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, qasm3
 from qiskit.circuit import (
     BoxOp,
     ControlledGate,
@@ -52,11 +51,17 @@ from qiskit_braket_provider.providers.gate_mappings import (
     _PAULI_MAP,
     _QISKIT_CONTROLLED_GATE_NAMES_TO_BRAKET_GATES,
     _QISKIT_GATE_NAME_TO_BRAKET_GATE,
+    _QISKIT_TO_BRAKET_OQ3_NAMES,
     _reverse_endianness,
 )
 from qiskit_braket_provider.providers.qasm_context import (
     _QiskitProgramContext,
     _sympy_to_qiskit,
+)
+from qiskit_braket_provider.providers.oq3_utils import _post_process_oq3
+from qiskit_braket_provider.providers.passes import (
+    ConsolidateClbits,
+    WrapInVerbatimBox,
 )
 from qiskit_braket_provider.providers.target import (
     _get_controlled_gateset,  # ruff:ignore[unused-import]
@@ -732,3 +737,191 @@ def convert_qiskit_to_braket_circuits(
     )
     for circuit in circuits:
         yield to_braket(circuit)
+
+
+_RESERVED_OQ3_KEYWORDS = frozenset({"measure", "barrier", "box"})
+
+
+def _collect_basis_gates(instructions: Iterable[QiskitInstruction]) -> set[str]:
+    """Collect non-reserved gate names from instructions, descending into BoxOps.
+
+    Reserved OpenQASM 3 statement keywords (``measure``, ``barrier``, ``box``) are
+    excluded because ``qasm3.dumps`` rejects them as ``basis_gates``. Nested boxes
+    are traversed so their inner gates are also collected.
+    """
+    gates: set[str] = set()
+    for instr in instructions:
+        name = instr.operation.name
+        if name == "box":
+            for block in instr.operation.blocks:
+                gates |= _collect_basis_gates(block.data)
+        elif name not in _RESERVED_OQ3_KEYWORDS:
+            gates.add(name)
+    return gates
+
+
+def to_oq3(
+    circuit: QuantumCircuit,
+    *,
+    basis_gates: Collection[str] | None = None,
+    qubit_labels: Sequence[int] | None = None,
+    should_wrap_verbatim: bool = False,
+    verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
+) -> str:
+    """Convert a compiled Qiskit QuantumCircuit to a Braket-compatible OpenQASM 3 string.
+
+    This function applies OQ3-preparation passes (classical bit consolidation,
+    optional verbatim wrapping) and serializes the circuit to OpenQASM 3 with
+    Braket-compatible gate names and qubit addressing.
+
+    Args:
+        circuit: A compiled Qiskit QuantumCircuit ready for serialization.
+        basis_gates: Gate names to treat as basis gates during serialization.
+            These should be **Qiskit** gate names (the function handles renaming
+            to Braket names internally). If ``None``, all gates in the circuit are
+            treated as basis gates.
+        qubit_labels: Physical qubit indices for the target device. If provided,
+            virtual qubits are remapped to physical qubit notation (``$0``, ``$1``, etc.).
+        should_wrap_verbatim: Whether to wrap the circuit in a verbatim box.
+        verbatim_box_name: Label for verbatim BoxOp identification.
+
+    Returns:
+        An OpenQASM 3 string compatible with Amazon Braket.
+    """
+    pm = PassManager()
+    pm.append(ConsolidateClbits())
+    if should_wrap_verbatim:
+        pm.append(WrapInVerbatimBox(verbatim_box_name))
+    circuit = pm.run(circuit)
+
+    if basis_gates is None:
+        basis_gates = list(_collect_basis_gates(circuit.data))
+
+    needs_renaming = bool(set(basis_gates) & _QISKIT_TO_BRAKET_OQ3_NAMES.keys())
+
+    oq3_source = qasm3.dumps(
+        circuit,
+        includes=[],
+        basis_gates=list(basis_gates),
+        disable_constants=True,
+    )
+
+    output_names = (circuit.metadata or {}).get("braket_output_variables", {})
+    return _post_process_oq3(
+        oq3_source,
+        qubit_labels,
+        rename_gates=needs_renaming,
+        output_names=output_names,
+    )
+
+
+@overload
+def compile_to_oq3(
+    circuits: QuantumCircuit,
+    **kwargs,
+) -> str: ...
+
+
+@overload
+def compile_to_oq3(
+    circuits: Iterable[QuantumCircuit],
+    **kwargs,
+) -> list[str]: ...
+
+
+def compile_to_oq3(
+    circuits: QuantumCircuit | Iterable[QuantumCircuit],
+    *,
+    qubit_labels: Sequence[int] | None = None,
+    target: Target | None = None,
+    verbatim: bool = False,
+    basis_gates: Collection[str] | None = None,
+    coupling_map: list[list[int]] | None = None,
+    optimization_level: int = 0,
+    callback: Callable | None = None,
+    num_processes: int | None = None,
+    pass_manager: PassManager | None = None,
+    braket_device: Device | None = None,
+    verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME,
+    layout_method: str | None = None,
+    routing_method: str | None = None,
+    seed_transpiler: int | None = None,
+) -> str | list[str]:
+    """Compile Qiskit circuits to Braket-compatible OpenQASM 3 strings.
+
+    This is the primary entry point for the OQ3 output path. It orchestrates:
+    1. Compilation via Qiskit's transpiler (with verbatim box preservation)
+    2. Serialization to OpenQASM 3 with Braket-compatible formatting
+
+    The compilation step reuses the existing ``_compile()`` pipeline, including
+    verbatim box extraction/restoration and device-aware transpilation.
+
+    Args:
+        circuits: One or more Qiskit QuantumCircuits to compile.
+        qubit_labels: Physical qubit indices on the target device.
+        target: A Qiskit transpiler target describing device constraints.
+        verbatim: If ``True``, wrap the circuit in a verbatim box (no compilation
+            by QBP or the service).
+        basis_gates: Gate names supported by the target device (Qiskit names).
+        coupling_map: Qubit connectivity as ``[control, target]`` pairs.
+        optimization_level: Transpiler optimization level (0-3). Default: 0.
+        callback: Callback function passed to the transpiler.
+        num_processes: Number of parallel processes for transpilation.
+        pass_manager: A custom Qiskit PassManager.
+        braket_device: A Braket Device to derive target and qubit labels from.
+        verbatim_box_name: Label identifying verbatim BoxOp nodes.
+        layout_method: Layout method for the transpiler.
+        routing_method: Routing method for the transpiler.
+        seed_transpiler: Seed for reproducible transpilation.
+
+    Returns:
+        An OpenQASM 3 string (single circuit) or list of strings (multiple circuits).
+
+    Raises:
+        ValueError: If mutually exclusive compilation options are specified.
+        TypeError: If inputs are not QuantumCircuits.
+    """
+    single_instance = isinstance(circuits, QuantumCircuit)
+    if single_instance:
+        circuits = [circuits]
+
+    result = _compile(
+        circuits,
+        qubit_labels=qubit_labels,
+        target=target,
+        verbatim=verbatim if not pass_manager else None,
+        basis_gates=basis_gates,
+        coupling_map=coupling_map,
+        optimization_level=optimization_level,
+        callback=callback,
+        num_processes=num_processes,
+        pass_manager=pass_manager,
+        braket_device=braket_device,
+        verbatim_box_name=verbatim_box_name,
+        layout_method=layout_method,
+        routing_method=routing_method,
+        seed_transpiler=seed_transpiler,
+    )
+
+    should_wrap_verbatim = (
+        verbatim
+        or pass_manager is not None
+        or target is not None
+        or braket_device is not None
+    )
+    effective_basis_gates = result.basis_gates
+    if effective_basis_gates is None and result.target is not None:
+        effective_basis_gates = set(result.target.operation_names) - {"measure", "barrier"}
+
+    oq3_strings = [
+        to_oq3(
+            circ,
+            basis_gates=effective_basis_gates,
+            qubit_labels=result.qubit_labels,
+            should_wrap_verbatim=should_wrap_verbatim,
+            verbatim_box_name=verbatim_box_name,
+        )
+        for circ in result.circuits
+    ]
+
+    return oq3_strings[0] if single_instance else oq3_strings

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -824,7 +824,7 @@ def compile_to_oq3(
 
 
 @overload
-def compile_to_oq3(  # type: ignore[misc]
+def compile_to_oq3(  # type: ignore[overload-cannot-match]
     circuits: Iterable[QuantumCircuit],
     **kwargs,
 ) -> list[str]: ...

--- a/qiskit_braket_provider/providers/gate_mappings.py
+++ b/qiskit_braket_provider/providers/gate_mappings.py
@@ -4,6 +4,7 @@ This module contains the gate mapping dictionaries and constants used across
 adapter.py, target.py, qasm_context.py, and compilation.py.
 """
 
+import re
 from collections.abc import Callable
 from math import inf, pi
 
@@ -74,6 +75,18 @@ _BRAKET_TO_QISKIT_NAMES = {
     "unitary": "unitary",
     "kraus": "kraus",
 }
+
+_QISKIT_TO_BRAKET_OQ3_NAMES: dict[str, str] = {
+    qiskit_name: braket_name
+    for braket_name, qiskit_name in _BRAKET_TO_QISKIT_NAMES.items()
+    if braket_name != qiskit_name
+}
+
+_GATE_RENAME_PATTERN = re.compile(
+    r"(?<![a-zA-Z_])"
+    r"(" + "|".join(re.escape(name) for name in sorted(_QISKIT_TO_BRAKET_OQ3_NAMES, key=len, reverse=True)) + r")"
+    r"(?=\s|[(])"
+)
 
 _CONTROLLED_GATES_BY_QUBIT_COUNT = {
     1: {

--- a/qiskit_braket_provider/providers/gate_mappings.py
+++ b/qiskit_braket_provider/providers/gate_mappings.py
@@ -84,7 +84,11 @@ _QISKIT_TO_BRAKET_OQ3_NAMES: dict[str, str] = {
 
 _GATE_RENAME_PATTERN = re.compile(
     r"(?<![a-zA-Z_])"
-    r"(" + "|".join(re.escape(name) for name in sorted(_QISKIT_TO_BRAKET_OQ3_NAMES, key=len, reverse=True)) + r")"
+    r"("
+    + "|".join(
+        re.escape(name) for name in sorted(_QISKIT_TO_BRAKET_OQ3_NAMES, key=len, reverse=True)
+    )
+    + r")"
     r"(?=\s|[(])"
 )
 

--- a/qiskit_braket_provider/providers/oq3_utils.py
+++ b/qiskit_braket_provider/providers/oq3_utils.py
@@ -49,17 +49,15 @@ def _post_process_oq3(
     if rename_gates:
         oq3_source = _rename_gates(oq3_source)
     oq3_source = _remap_qubits(oq3_source, qubit_labels)
-    oq3_source = _normalize_formatting(oq3_source, output_names)
-    return oq3_source
+    return _normalize_formatting(oq3_source, output_names)
 
 
 def _rename_gates(oq3_source: str) -> str:
     """Replace Qiskit gate names with Braket-compatible names."""
-    lines = oq3_source.split("\n")
     result = []
-    for line in lines:
+    for line in oq3_source.split("\n"):
         stripped = line.lstrip()
-        if stripped.startswith("OPENQASM") or stripped.startswith("//"):
+        if stripped.startswith(("OPENQASM", "//")):
             result.append(line)
             continue
         result.append(_GATE_RENAME_PATTERN.sub(_gate_replacer, line))
@@ -110,13 +108,11 @@ def _normalize_formatting(oq3_source: str, output_names: Iterable[str] = ()) -> 
     - Removes empty lines
     """
     output_set = set(output_names)
-    lines = []
-    for line in oq3_source.split("\n"):
-        line = line.lstrip()
-        line = line.replace("float[64]", "float")
+    lines: list[str] = []
+    for raw_line in oq3_source.split("\n"):
+        line = raw_line.lstrip().replace("float[64]", "float")
         if line == "box {":
-            lines.append("#pragma braket verbatim")
-            lines.append("box{")
+            lines.extend(("#pragma braket verbatim", "box{"))
             continue
         lines.append(_restore_output_declaration(line, output_set))
     return "\n".join(line for line in lines if line != "")

--- a/qiskit_braket_provider/providers/oq3_utils.py
+++ b/qiskit_braket_provider/providers/oq3_utils.py
@@ -1,0 +1,135 @@
+"""Post-processing helpers for OpenQASM 3 emission targeting Amazon Braket.
+
+These utilities transform the raw output of ``qiskit.qasm3.dumps()`` into
+Braket-compatible OpenQASM 3 by renaming Qiskit gates to their Braket
+equivalents, remapping virtual qubits to physical qubit labels, and normalizing
+formatting to match Braket service conventions.
+"""
+
+import re
+from collections.abc import Iterable, Sequence
+
+from qiskit_braket_provider.providers.gate_mappings import (
+    _GATE_RENAME_PATTERN,
+    _QISKIT_TO_BRAKET_OQ3_NAMES,
+)
+
+
+def _post_process_oq3(
+    oq3_source: str,
+    qubit_labels: Sequence[int] | None,
+    rename_gates: bool = True,
+    output_names: Iterable[str] = (),
+) -> str:
+    """Post-process qasm3.dumps() output for Braket compatibility.
+
+    Performs the following transformations:
+    1. Renames Qiskit gate names to Braket-compatible OQ3 gate names (when needed)
+    2. Remaps virtual qubit references to physical qubit labels
+    3. Inserts ``#pragma braket verbatim`` before any ``box`` statements
+    4. Replaces ``float[64]`` with ``float`` for parameter declarations
+    5. Restores ``output`` keyword on classical register declarations whose name
+       is listed in ``output_names``
+    6. Strips indentation and removes empty lines (Braket convention)
+
+    Args:
+        oq3_source: Raw OpenQASM 3 string from ``qasm3.dumps()``.
+        qubit_labels: Physical qubit indices for remapping. If ``None``,
+            contiguous indices starting from 0 are assumed.
+        rename_gates: Whether to rename Qiskit gate names to Braket equivalents.
+            Set to ``False`` when the circuit already uses Braket-native gate names
+            (e.g., after compiling to a device-native gate set).
+        output_names: Names of classical registers that should be re-declared as
+            OpenQASM ``output`` variables. Sourced from the compiled circuit's
+            ``metadata["braket_output_variables"]``.
+
+    Returns:
+        The post-processed OpenQASM 3 string.
+    """
+    if rename_gates:
+        oq3_source = _rename_gates(oq3_source)
+    oq3_source = _remap_qubits(oq3_source, qubit_labels)
+    oq3_source = _normalize_formatting(oq3_source, output_names)
+    return oq3_source
+
+
+def _rename_gates(oq3_source: str) -> str:
+    """Replace Qiskit gate names with Braket-compatible names."""
+    lines = oq3_source.split("\n")
+    result = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("OPENQASM") or stripped.startswith("//"):
+            result.append(line)
+            continue
+        result.append(_GATE_RENAME_PATTERN.sub(_gate_replacer, line))
+    return "\n".join(result)
+
+
+def _gate_replacer(match: re.Match) -> str:
+    """Regex replacer callback for gate renaming."""
+    return _QISKIT_TO_BRAKET_OQ3_NAMES[match.group(1)]
+
+
+def _remap_qubits(oq3_source: str, qubit_labels: Sequence[int] | None) -> str:
+    """Replace qubit references with physical qubit notation.
+
+    Handles two cases produced by ``qasm3.dumps()``:
+
+    1. **Layout-aware output** (``$N`` notation, no ``qubit[N] q;`` declaration):
+       when the circuit's ``layout`` property is set, Qiskit emits physical
+       qubit references directly. Remap ``$N`` → ``$qubit_labels[N]``.
+
+    2. **Virtual register output** (``qubit[N] q; ... q[i]``): when no layout
+       is attached, Qiskit falls back to virtual register syntax. Remove the
+       ``qubit[N] q;`` declaration and remap ``q[i]`` → ``$qubit_labels[i]``.
+    """
+    if not qubit_labels:
+        return oq3_source
+
+    decl = re.compile(r"^qubit\[\d+\]\s+(\w+);\n?", re.MULTILINE)
+    match = decl.search(oq3_source)
+    if match:
+        reg_name = match.group(1)
+        oq3_source = decl.sub("", oq3_source, count=1)
+        for i, label in enumerate(qubit_labels):
+            oq3_source = oq3_source.replace(f"{reg_name}[{i}]", f"${label}")
+        return oq3_source
+
+    return re.sub(r"\$(\d+)", lambda m: f"${qubit_labels[int(m.group(1))]}", oq3_source)
+
+
+def _normalize_formatting(oq3_source: str, output_names: Iterable[str] = ()) -> str:
+    """Normalize OQ3 formatting to match Braket service conventions.
+
+    - Strips leading indentation from all lines
+    - Replaces ``float[64]`` with ``float`` in parameter declarations
+    - Inserts ``#pragma braket verbatim`` before ``box`` statements
+    - Removes space in ``box {`` → ``box{``
+    - Restores ``output`` keyword on registers listed in ``output_names``
+    - Removes empty lines
+    """
+    output_set = set(output_names)
+    lines = []
+    for line in oq3_source.split("\n"):
+        line = line.lstrip()
+        line = line.replace("float[64]", "float")
+        if line == "box {":
+            lines.append("#pragma braket verbatim")
+            lines.append("box{")
+            continue
+        lines.append(_restore_output_declaration(line, output_set))
+    return "\n".join(line for line in lines if line != "")
+
+
+def _restore_output_declaration(line: str, output_names: set) -> str:
+    """Prefix ``output`` onto a bit declaration ``qasm3.dumps`` rendered as plain.
+
+    Qiskit models an output variable as an ordinary ``ClassicalRegister``, which
+    ``qasm3.dumps`` renders as ``"bit[N] name;"``, so the keyword has to be put
+    back on declarations whose name appears in ``output_names``.
+    """
+    if not line.startswith("bit["):
+        return line
+    name = line.removesuffix(";").rpartition(" ")[2]
+    return f"output {line}" if name in output_names else line

--- a/qiskit_braket_provider/providers/passes/__init__.py
+++ b/qiskit_braket_provider/providers/passes/__init__.py
@@ -1,5 +1,7 @@
 """Qiskit transpiler passes for the Braket provider."""
 
 from .basis_rotation_pass import AddBasisRotationAndMeasurement as AddBasisRotationAndMeasurement
+from .oq3_processing import ConsolidateClbits as ConsolidateClbits
+from .oq3_processing import WrapInVerbatimBox as WrapInVerbatimBox
 from .verbatim_passes import ExtractVerbatimBoxes as ExtractVerbatimBoxes
 from .verbatim_passes import RestoreVerbatimBoxes as RestoreVerbatimBoxes

--- a/qiskit_braket_provider/providers/passes/oq3_processing.py
+++ b/qiskit_braket_provider/providers/passes/oq3_processing.py
@@ -1,0 +1,112 @@
+"""Transpiler passes for preparing circuits for OpenQASM 3 serialization."""
+
+from qiskit.circuit import BoxOp, ClassicalRegister, Measure, QuantumCircuit
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+
+from qiskit_braket_provider.providers.gate_mappings import _BRAKET_VERBATIM_BOX_NAME
+
+_OUTPUT_VARIABLES_KEY = "braket_output_variables"
+
+
+class ConsolidateClbits(TransformationPass):
+    """Expose every plain Clbit under a single ClassicalRegister named ``"b"``.
+
+    "Plain" means any bit not declared ``output`` in the source program.
+    Registers named in the circuit's ``"braket_output_variables"`` metadata
+    are kept as-is so ``_post_process_oq3`` can re-emit them as 
+    ``output bit[N] name;`` declarations.
+
+    The underlying Clbit objects are reused as the new register's members, so
+    nothing on any DAGOpNode has to be rewired: Measure cargs and IfElseOp
+    conditions continue to point at the same bits, which are now also members
+    of ``"b"``. ``qasm3.dumps`` then emits ``bit[N] b;`` plus ``b[i]``
+    references automatically.
+
+    If ``"b"`` collides with an output variable name, the fallback is
+    ``"b0"``, ``"b1"``, ... — whichever is first not shadowed.
+    """
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Consolidate plain classical bits into a single register."""
+        if not dag.clbits:
+            return dag
+        output_names = set((dag.metadata or {}).get(_OUTPUT_VARIABLES_KEY, {}))
+        # Keep output-variable registers; drop the rest but keep their Clbits.
+        kept_bits = set()
+        for creg in list(dag.cregs.values()):
+            if creg.name in output_names:
+                kept_bits.update(creg)
+            else:
+                dag.remove_cregs(creg)
+        plain = [bit for bit in dag.clbits if bit not in kept_bits]
+        if plain:
+            dag.add_creg(ClassicalRegister(name=_plain_register_name(output_names), bits=plain))
+        return dag
+
+
+def _plain_register_name(taken: set) -> str:
+    """Return ``"b"``, or the first ``"b<i>"`` not shadowed by an output variable name."""
+    if "b" not in taken:
+        return "b"
+    i = 0
+    while f"b{i}" in taken:
+        i += 1
+    return f"b{i}"
+
+
+class WrapInVerbatimBox(TransformationPass):
+    """Wrap circuit operations in a verbatim BoxOp for ``#pragma braket verbatim``.
+
+    All non-measurement operations are collected into an inner circuit and wrapped
+    in a :class:`~qiskit.circuit.BoxOp` with a verbatim label. Measurements are
+    placed after the box.
+
+    Preserves ``dag.metadata`` on the resulting DAG so downstream passes and
+    serializers still see the input circuit's metadata (notably
+    ``braket_output_variables``).
+
+    Args:
+        verbatim_box_name: Label for the BoxOp. Default: ``"verbatim"``.
+    """
+
+    def __init__(self, verbatim_box_name: str = _BRAKET_VERBATIM_BOX_NAME):
+        super().__init__()
+        self._verbatim_box_name = verbatim_box_name
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Wrap non-measurement operations in a verbatim BoxOp."""
+        circuit = dag_to_circuit(dag)
+        num_qubits = circuit.num_qubits
+
+        inner = QuantumCircuit(num_qubits, circuit.num_clbits)
+        measurements = []
+
+        for instr in circuit.data:
+            if isinstance(instr.operation, Measure):
+                measurements.append(instr)
+            else:
+                qubit_indices = [circuit.find_bit(q).index for q in instr.qubits]
+                clbit_indices = [circuit.find_bit(c).index for c in instr.clbits]
+                inner.append(
+                    instr.operation,
+                    [inner.qubits[i] for i in qubit_indices],
+                    [inner.clbits[i] for i in clbit_indices],
+                )
+
+        result = QuantumCircuit(*circuit.qregs, *circuit.cregs)
+        box_op = BoxOp(inner, label=self._verbatim_box_name)
+        result.append(box_op, result.qubits, result.clbits)
+
+        for instr in measurements:
+            qubit_indices = [circuit.find_bit(q).index for q in instr.qubits]
+            clbit_indices = [circuit.find_bit(c).index for c in instr.clbits]
+            result.append(
+                instr.operation,
+                [result.qubits[i] for i in qubit_indices],
+                [result.clbits[i] for i in clbit_indices],
+            )
+
+        result.metadata = dag.metadata
+        return circuit_to_dag(result)

--- a/qiskit_braket_provider/providers/passes/oq3_processing.py
+++ b/qiskit_braket_provider/providers/passes/oq3_processing.py
@@ -15,7 +15,7 @@ class ConsolidateClbits(TransformationPass):
 
     "Plain" means any bit not declared ``output`` in the source program.
     Registers named in the circuit's ``"braket_output_variables"`` metadata
-    are kept as-is so ``_post_process_oq3`` can re-emit them as 
+    are kept as-is so ``_post_process_oq3`` can re-emit them as
     ``output bit[N] name;`` declarations.
 
     The underlying Clbit objects are reused as the new register's members, so

--- a/test/unit_tests/test_oq3.py
+++ b/test/unit_tests/test_oq3.py
@@ -1,5 +1,7 @@
 """Tests for the OQ3 output path (compile_to_oq3, to_oq3)."""
 
+from collections.abc import Callable
+
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.circuit import (
@@ -49,7 +51,7 @@ def sim() -> LocalSimulator:
     return LocalSimulator("braket_sv")
 
 
-def _assert_contents(source: str, expected_present, expected_absent) -> None:
+def _assert_contents(source: str, expected_present: list[str], expected_absent: list[str]) -> None:
     for s in expected_present:
         assert s in source
     for s in expected_absent:
@@ -84,7 +86,7 @@ def _output_circuit(output_names: tuple[str, ...], sizes: tuple[int, ...]) -> Qu
         for i in range(size):
             qc.measure(q_idx, creg[i])
             q_idx += 1
-    qc.metadata = {"braket_output_variables": {name: None for name in output_names}}
+    qc.metadata = {"braket_output_variables": dict.fromkeys(output_names)}
     return qc
 
 
@@ -131,6 +133,28 @@ def _bell_with_verbatim_boxop() -> QuantumCircuit:
     return outer
 
 
+def _no_clbits_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    return qc
+
+
+def _shadow_b_and_b0_circuit() -> QuantumCircuit:
+    """Output registers 'b' and 'b0' both shadow the plain-bit fallback names."""
+    b = ClassicalRegister(1, "b")
+    b0 = ClassicalRegister(1, "b0")
+    qc = QuantumCircuit(3)
+    qc.add_register(b)
+    qc.add_register(b0)
+    qc.add_bits([Clbit()])
+    qc.measure(0, b[0])
+    qc.measure(1, b0[0])
+    qc.measure(2, qc.clbits[2])
+    qc.metadata = {"braket_output_variables": {"b": None, "b0": None}}
+    return qc
+
+
 @pytest.mark.parametrize(
     "qubit_labels,expected_present,expected_absent",
     [
@@ -139,12 +163,17 @@ def _bell_with_verbatim_boxop() -> QuantumCircuit:
     ],
     ids=["no_labels", "non_contiguous_labels"],
 )
-def test_to_oq3_qubit_remapping(bell_circuit, qubit_labels, expected_present, expected_absent):
+def test_to_oq3_qubit_remapping(
+    bell_circuit: QuantumCircuit,
+    qubit_labels: list[int] | None,
+    expected_present: list[str],
+    expected_absent: list[str],
+) -> None:
     oq3 = to_oq3(bell_circuit, basis_gates=["h", "cx"], qubit_labels=qubit_labels)
     _assert_contents(oq3, expected_present, expected_absent)
 
 
-def test_to_oq3_verbatim_wrapping(bell_circuit):
+def test_to_oq3_verbatim_wrapping(bell_circuit: QuantumCircuit) -> None:
     oq3 = to_oq3(
         bell_circuit,
         basis_gates=["h", "cx"],
@@ -158,7 +187,7 @@ def test_to_oq3_verbatim_wrapping(bell_circuit):
     )
 
 
-def test_to_oq3_consolidates_classical_registers():
+def test_to_oq3_consolidates_classical_registers() -> None:
     qr = QuantumRegister(3, "q")
     cr1 = ClassicalRegister(2, "meas1")
     cr2 = ClassicalRegister(1, "meas2")
@@ -183,7 +212,7 @@ def test_to_oq3_consolidates_classical_registers():
     )
 
 
-def test_to_oq3_single_creg_unchanged(bell_circuit):
+def test_to_oq3_single_creg_unchanged(bell_circuit: QuantumCircuit) -> None:
     assert "bit[2] b;" in to_oq3(bell_circuit, basis_gates=["h", "cx"])
 
 
@@ -207,7 +236,9 @@ def test_to_oq3_single_creg_unchanged(bell_circuit):
     ],
     ids=["parameter", "parameter_vector"],
 )
-def test_to_oq3_parameterized_circuits(build_params, build_circuit, expected_present):
+def test_to_oq3_parameterized_circuits(
+    build_params: Callable, build_circuit: Callable, expected_present: list[str]
+) -> None:
     params = build_params()
     num_qubits = 1 if len(params) == 1 else 2
     qc = QuantumCircuit(num_qubits, num_qubits)
@@ -215,18 +246,20 @@ def test_to_oq3_parameterized_circuits(build_params, build_circuit, expected_pre
     qubit_labels = [5] if num_qubits == 1 else None
     oq3 = to_oq3(
         qc,
-        basis_gates=[str(instr.operation.name) for instr in qc.data if instr.operation.name != "measure"],
+        basis_gates=[
+            str(instr.operation.name) for instr in qc.data if instr.operation.name != "measure"
+        ],
         qubit_labels=qubit_labels,
     )
     _assert_contents(oq3, expected_present, [])
 
 
-def test_to_oq3_auto_detects_basis_gates(bell_circuit):
+def test_to_oq3_auto_detects_basis_gates(bell_circuit: QuantumCircuit) -> None:
     oq3 = to_oq3(bell_circuit)
     _assert_contents(oq3, ["h ", "cnot "], ["gate "])
 
 
-def test_to_oq3_skips_renaming_for_native_gates():
+def test_to_oq3_skips_renaming_for_native_gates() -> None:
     """When all gates are already Braket-native, no renaming occurs."""
     qc = QuantumCircuit(2, 2)
     qc.h(0)
@@ -255,14 +288,16 @@ def test_to_oq3_skips_renaming_for_native_gates():
     ],
     ids=["sx_sdg_tdg_cx", "rxx_ryy_rzz", "id", "p", "cp"],
 )
-def test_gate_renaming_in_output(build_circuit, expected_present, expected_absent):
+def test_gate_renaming_in_output(
+    build_circuit: Callable, expected_present: list[str], expected_absent: list[str]
+) -> None:
     qc = QuantumCircuit(2, 2)
     build_circuit(qc)
     qc.measure([0, 1], [0, 1])
     _assert_contents(compile_to_oq3(qc), expected_present, expected_absent)
 
 
-def test_compile_to_oq3_list_input(bell_circuit):
+def test_compile_to_oq3_list_input(bell_circuit: QuantumCircuit) -> None:
     results = compile_to_oq3([bell_circuit, bell_circuit])
     assert isinstance(results, list)
     assert len(results) == 2
@@ -273,19 +308,19 @@ def test_compile_to_oq3_list_input(bell_circuit):
     "build_circuit,compile_kwargs,expected_present,expected_absent",
     [
         (
-            lambda bell: bell,
+            lambda _bell: _bell,
             {"verbatim": True, "qubit_labels": [0, 1]},
             ["#pragma braket verbatim", "box{"],
             [],
         ),
         (
-            lambda bell: bell,
+            lambda _bell: _bell,
             {"target": _bell_circuit_target(), "qubit_labels": [0, 1]},
             ["OPENQASM 3.0;", "h ", "cnot ", "#pragma braket verbatim", "box{"],
             [],
         ),
         (
-            lambda bell: _bell_with_verbatim_boxop(),
+            lambda _bell: _bell_with_verbatim_boxop(),
             {"qubit_labels": [0, 1]},
             ["h ", "cnot "],
             [],
@@ -294,8 +329,12 @@ def test_compile_to_oq3_list_input(bell_circuit):
     ids=["verbatim_flag", "target", "existing_verbatim_box"],
 )
 def test_compile_to_oq3_verbatim_wrapping_triggers(
-    bell_circuit, build_circuit, compile_kwargs, expected_present, expected_absent
-):
+    bell_circuit: QuantumCircuit,
+    build_circuit: Callable,
+    compile_kwargs: dict,
+    expected_present: list[str],
+    expected_absent: list[str],
+) -> None:
     _assert_contents(
         compile_to_oq3(build_circuit(bell_circuit), **compile_kwargs),
         expected_present,
@@ -303,7 +342,7 @@ def test_compile_to_oq3_verbatim_wrapping_triggers(
     )
 
 
-def test_compile_to_oq3_non_contiguous_qubit_labels(ghz_circuit):
+def test_compile_to_oq3_non_contiguous_qubit_labels(ghz_circuit: QuantumCircuit) -> None:
     _assert_contents(
         compile_to_oq3(ghz_circuit, verbatim=True, qubit_labels=[0, 4, 7]),
         ["$0", "$4", "$7"],
@@ -320,7 +359,12 @@ def test_compile_to_oq3_non_contiguous_qubit_labels(ghz_circuit):
     ],
     ids=["default", "verbatim", "renamed_gates"],
 )
-def test_compile_to_oq3_accepted_by_braket_simulator(sim, verbatim, qubit_labels, build_circuit):
+def test_compile_to_oq3_accepted_by_braket_simulator(
+    sim: LocalSimulator,
+    verbatim: bool,
+    qubit_labels: list[int] | None,
+    build_circuit: Callable,
+) -> None:
     qc = QuantumCircuit(2, 2)
     build_circuit(qc)
     qc.measure([0, 1], [0, 1])
@@ -351,7 +395,7 @@ def test_compile_to_oq3_accepted_by_braket_simulator(sim, verbatim, qubit_labels
     ],
     ids=["gate_positions", "preserves_comments", "parametric_gates"],
 )
-def test_rename_gates(source, expected_present, expected_absent):
+def test_rename_gates(source: str, expected_present: list[str], expected_absent: list[str]) -> None:
     _assert_contents(_rename_gates(source), expected_present, expected_absent)
 
 
@@ -366,6 +410,13 @@ def test_rename_gates(source, expected_present, expected_absent):
             False,
         ),
         (
+            "OPENQASM 3.0;\nbit[2] c;\nh $0;\ncnot $0, $1;\n",
+            [3, 7],
+            ["$3", "$7"],
+            ["$0;", "$1;"],
+            False,
+        ),
+        (
             "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n",
             None,
             [],
@@ -373,9 +424,15 @@ def test_rename_gates(source, expected_present, expected_absent):
             True,
         ),
     ],
-    ids=["declaration_and_refs", "noop_when_none"],
+    ids=["virtual_form", "layout_aware_form", "noop_when_none"],
 )
-def test_remap_qubits(source, qubit_labels, expected_present, expected_absent, expect_unchanged):
+def test_remap_qubits(
+    source: str,
+    qubit_labels: list[int] | None,
+    expected_present: list[str],
+    expected_absent: list[str],
+    expect_unchanged: bool,
+) -> None:
     result = _remap_qubits(source, qubit_labels)
     if expect_unchanged:
         assert result == source
@@ -408,33 +465,30 @@ def test_remap_qubits(source, qubit_labels, expected_present, expected_absent, e
     ],
     ids=["inserts_pragma", "strips_indentation", "noop_without_box", "replaces_float64"],
 )
-def test_normalize_formatting(source, expected_present, expected_absent):
+def test_normalize_formatting(
+    source: str, expected_present: list[str], expected_absent: list[str]
+) -> None:
     _assert_contents(_normalize_formatting(source), expected_present, expected_absent)
 
 
 @pytest.mark.parametrize(
     "build_circuit,expected_creg_count,expected_num_clbits",
     [
-        (
-            lambda: _consolidate_two_regs_circuit(),
-            1,
-            2,
-        ),
-        (
-            lambda: _single_reg_circuit(),
-            1,
-            2,
-        ),
+        (_consolidate_two_regs_circuit, 1, 2),
+        (_single_reg_circuit, 1, 2),
+        (_no_clbits_circuit, 0, 0),
     ],
-    ids=["two_regs", "single_reg_noop"],
+    ids=["two_regs", "single_reg_noop", "no_clbits"],
 )
-def test_consolidate_clbits_pass(build_circuit, expected_creg_count, expected_num_clbits):
+def test_consolidate_clbits_pass(
+    build_circuit: Callable, expected_creg_count: int, expected_num_clbits: int
+) -> None:
     result = PassManager([ConsolidateClbits()]).run(build_circuit())
     assert len(result.cregs) == expected_creg_count
     assert result.num_clbits == expected_num_clbits
 
 
-def test_wrap_in_verbatim_box_pass(bell_circuit):
+def test_wrap_in_verbatim_box_pass(bell_circuit: QuantumCircuit) -> None:
     result = PassManager([WrapInVerbatimBox()]).run(bell_circuit)
     op_names = [instr.operation.name for instr in result.data]
     assert "box" in op_names
@@ -447,12 +501,12 @@ def test_wrap_in_verbatim_box_pass(bell_circuit):
     assert "cx" in inner_ops
 
 
-def test_compile_to_oq3_raises_on_invalid_input():
+def test_compile_to_oq3_raises_on_invalid_input() -> None:
     with pytest.raises(TypeError):
         compile_to_oq3("not a circuit")
 
 
-def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit):
+def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit: QuantumCircuit) -> None:
     target = Target(num_qubits=2)
     target.add_instruction(HGate(), name="h")
     target.add_instruction(CXGate(), name="cx")
@@ -476,7 +530,7 @@ def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit):
             [],
         ),
         (
-            lambda: _output_and_scratch_circuit(),
+            _output_and_scratch_circuit,
             {},
             ["output bit[2] first;", "bit[1] b;"],
             ["scratch"],
@@ -488,9 +542,15 @@ def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit):
             [],
         ),
         (
-            lambda: _output_and_shadowed_plain_circuit(),
+            _output_and_shadowed_plain_circuit,
             {},
             ["output bit[1] b;", "bit[1] b0;"],
+            [],
+        ),
+        (
+            _shadow_b_and_b0_circuit,
+            {},
+            ["output bit[1] b;", "output bit[1] b0;", "bit[1] b1;"],
             [],
         ),
     ],
@@ -500,17 +560,21 @@ def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit):
         "output_with_plain_bits",
         "output_survives_verbatim",
         "plain_name_avoids_shadow",
+        "plain_name_avoids_double_shadow",
     ],
 )
 def test_compile_to_oq3_output_declarations(
-    build_circuit, compile_kwargs, expected_present, expected_absent
-):
+    build_circuit: Callable,
+    compile_kwargs: dict,
+    expected_present: list[str],
+    expected_absent: list[str],
+) -> None:
     _assert_contents(
         compile_to_oq3(build_circuit(), **compile_kwargs), expected_present, expected_absent
     )
 
 
-def test_compile_to_oq3_output_declaration_precedes_verbatim_box():
+def test_compile_to_oq3_output_declaration_precedes_verbatim_box() -> None:
     """Output declarations stay outside the verbatim box."""
     qc = _output_circuit(("c",), (2,))
     oq3 = compile_to_oq3(qc, verbatim=True, qubit_labels=[0, 1])
@@ -525,7 +589,7 @@ def test_compile_to_oq3_output_declaration_precedes_verbatim_box():
     [{}, {"braket_output_variables": {}}, {"unrelated": "value"}],
     ids=["empty", "empty_output_map", "unrelated_key"],
 )
-def test_compile_to_oq3_no_output_metadata(bell_circuit, metadata):
+def test_compile_to_oq3_no_output_metadata(bell_circuit: QuantumCircuit, metadata: dict) -> None:
     """Without output metadata, no bit declaration is prefixed with `output`."""
     bell_circuit.metadata = metadata
     assert "output bit[" not in compile_to_oq3(bell_circuit)

--- a/test/unit_tests/test_oq3.py
+++ b/test/unit_tests/test_oq3.py
@@ -1,0 +1,531 @@
+"""Tests for the OQ3 output path (compile_to_oq3, to_oq3)."""
+
+import pytest
+from qiskit import QuantumCircuit
+from qiskit.circuit import (
+    BoxOp,
+    ClassicalRegister,
+    Clbit,
+    Measure,
+    Parameter,
+    ParameterVector,
+    QuantumRegister,
+)
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.transpiler import PassManager, Target
+
+from braket.devices import LocalSimulator
+from braket.ir.openqasm import Program
+from qiskit_braket_provider.providers.adapter import compile_to_oq3, to_oq3
+from qiskit_braket_provider.providers.oq3_utils import (
+    _normalize_formatting,
+    _remap_qubits,
+    _rename_gates,
+)
+from qiskit_braket_provider.providers.passes import ConsolidateClbits, WrapInVerbatimBox
+
+
+@pytest.fixture
+def bell_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+@pytest.fixture
+def ghz_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(3, 3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure(range(3), range(3))
+    return qc
+
+
+@pytest.fixture
+def sim() -> LocalSimulator:
+    return LocalSimulator("braket_sv")
+
+
+def _assert_contents(source: str, expected_present, expected_absent) -> None:
+    for s in expected_present:
+        assert s in source
+    for s in expected_absent:
+        assert s not in source
+
+
+def _consolidate_two_regs_circuit() -> QuantumCircuit:
+    qr = QuantumRegister(2, "q")
+    cr1 = ClassicalRegister(1, "a")
+    cr2 = ClassicalRegister(1, "b")
+    qc = QuantumCircuit(qr, cr1, cr2)
+    qc.h(0)
+    qc.measure(0, cr1[0])
+    qc.measure(1, cr2[0])
+    return qc
+
+
+def _single_reg_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+def _output_circuit(output_names: tuple[str, ...], sizes: tuple[int, ...]) -> QuantumCircuit:
+    """Build a circuit with each name mapped to a ClassicalRegister of the given size."""
+    total = sum(sizes)
+    qc = QuantumCircuit(total)
+    q_idx = 0
+    for name, size in zip(output_names, sizes, strict=True):
+        creg = ClassicalRegister(size, name)
+        qc.add_register(creg)
+        for i in range(size):
+            qc.measure(q_idx, creg[i])
+            q_idx += 1
+    qc.metadata = {"braket_output_variables": {name: None for name in output_names}}
+    return qc
+
+
+def _output_and_scratch_circuit() -> QuantumCircuit:
+    first = ClassicalRegister(2, "first")
+    scratch = ClassicalRegister(1, "scratch")
+    qc = QuantumCircuit(3)
+    qc.add_register(first)
+    qc.add_register(scratch)
+    qc.measure(0, first[0])
+    qc.measure(1, first[1])
+    qc.measure(2, scratch[0])
+    qc.metadata = {"braket_output_variables": {"first": None}}
+    return qc
+
+
+def _output_and_shadowed_plain_circuit() -> QuantumCircuit:
+    """Output register named 'b' forces plain-bit register to fall back to 'b0'."""
+    b = ClassicalRegister(1, "b")
+    qc = QuantumCircuit(2)
+    qc.add_register(b)
+    qc.add_bits([Clbit()])
+    qc.measure(0, b[0])
+    qc.measure(1, qc.clbits[1])
+    qc.metadata = {"braket_output_variables": {"b": None}}
+    return qc
+
+
+def _bell_circuit_target() -> Target:
+    target = Target(num_qubits=2)
+    target.add_instruction(HGate(), name="h")
+    target.add_instruction(CXGate(), name="cx")
+    target.add_instruction(Measure(), name="measure")
+    return target
+
+
+def _bell_with_verbatim_boxop() -> QuantumCircuit:
+    inner = QuantumCircuit(2)
+    inner.h(0)
+    inner.cx(0, 1)
+    outer = QuantumCircuit(2, 2)
+    outer.append(BoxOp(inner, label="verbatim"), [0, 1])
+    outer.measure([0, 1], [0, 1])
+    return outer
+
+
+@pytest.mark.parametrize(
+    "qubit_labels,expected_present,expected_absent",
+    [
+        (None, ["qubit[2] q;", "q[0]", "q[1]"], []),
+        ([0, 4], ["$0", "$4"], ["qubit[", "q["]),
+    ],
+    ids=["no_labels", "non_contiguous_labels"],
+)
+def test_to_oq3_qubit_remapping(bell_circuit, qubit_labels, expected_present, expected_absent):
+    oq3 = to_oq3(bell_circuit, basis_gates=["h", "cx"], qubit_labels=qubit_labels)
+    _assert_contents(oq3, expected_present, expected_absent)
+
+
+def test_to_oq3_verbatim_wrapping(bell_circuit):
+    oq3 = to_oq3(
+        bell_circuit,
+        basis_gates=["h", "cx"],
+        qubit_labels=[0, 1],
+        should_wrap_verbatim=True,
+    )
+    _assert_contents(
+        oq3,
+        ["#pragma braket verbatim", "box{", "h $0;", "cnot $0, $1;"],
+        [],
+    )
+
+
+def test_to_oq3_consolidates_classical_registers():
+    qr = QuantumRegister(3, "q")
+    cr1 = ClassicalRegister(2, "meas1")
+    cr2 = ClassicalRegister(1, "meas2")
+    qc = QuantumCircuit(qr, cr1, cr2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.measure(0, cr1[0])
+    qc.measure(1, cr1[1])
+    qc.measure(2, cr2[0])
+
+    oq3 = to_oq3(qc, basis_gates=["h", "cx"], qubit_labels=[0, 1, 7])
+    _assert_contents(
+        oq3,
+        [
+            "bit[3] b;",
+            "b[0] = measure $0;",
+            "b[1] = measure $1;",
+            "b[2] = measure $7;",
+        ],
+        ["meas1", "meas2"],
+    )
+
+
+def test_to_oq3_single_creg_unchanged(bell_circuit):
+    assert "bit[2] b;" in to_oq3(bell_circuit, basis_gates=["h", "cx"])
+
+
+@pytest.mark.parametrize(
+    "build_params,build_circuit,expected_present",
+    [
+        (
+            lambda: (Parameter("theta"),),
+            lambda qc, params: (qc.rx(params[0], 0), qc.measure(0, 0)),
+            ["input float theta;", "rx(theta) $5;"],
+        ),
+        (
+            lambda: ParameterVector("p", 2),
+            lambda qc, params: (
+                qc.rx(params[0], 0),
+                qc.ry(params[1], 1),
+                qc.measure([0, 1], [0, 1]),
+            ),
+            ["input float", "rx(", "ry("],
+        ),
+    ],
+    ids=["parameter", "parameter_vector"],
+)
+def test_to_oq3_parameterized_circuits(build_params, build_circuit, expected_present):
+    params = build_params()
+    num_qubits = 1 if len(params) == 1 else 2
+    qc = QuantumCircuit(num_qubits, num_qubits)
+    build_circuit(qc, params)
+    qubit_labels = [5] if num_qubits == 1 else None
+    oq3 = to_oq3(
+        qc,
+        basis_gates=[str(instr.operation.name) for instr in qc.data if instr.operation.name != "measure"],
+        qubit_labels=qubit_labels,
+    )
+    _assert_contents(oq3, expected_present, [])
+
+
+def test_to_oq3_auto_detects_basis_gates(bell_circuit):
+    oq3 = to_oq3(bell_circuit)
+    _assert_contents(oq3, ["h ", "cnot "], ["gate "])
+
+
+def test_to_oq3_skips_renaming_for_native_gates():
+    """When all gates are already Braket-native, no renaming occurs."""
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.rx(0.5, 1)
+    qc.measure([0, 1], [0, 1])
+    oq3 = to_oq3(qc, basis_gates=["h", "rx"])
+    _assert_contents(oq3, ["h ", "rx(0.5)"], ["cnot", "phaseshift"])
+
+
+@pytest.mark.parametrize(
+    "build_circuit,expected_present,expected_absent",
+    [
+        (
+            lambda qc: (qc.sx(0), qc.sdg(0), qc.tdg(1), qc.cx(0, 1)),
+            ["v ", "si ", "ti ", "cnot "],
+            ["sx ", "sdg ", "tdg ", "cx "],
+        ),
+        (
+            lambda qc: (qc.rxx(0.5, 0, 1), qc.ryy(0.3, 0, 1), qc.rzz(0.7, 0, 1)),
+            ["xx(0.5)", "yy(0.3)", "zz(0.7)"],
+            ["rxx", "ryy", "rzz"],
+        ),
+        (lambda qc: (qc.id(0),), ["i "], []),
+        (lambda qc: (qc.p(0.5, 0),), ["phaseshift(0.5)"], []),
+        (lambda qc: (qc.cp(0.5, 0, 1),), ["cphaseshift(0.5)"], []),
+    ],
+    ids=["sx_sdg_tdg_cx", "rxx_ryy_rzz", "id", "p", "cp"],
+)
+def test_gate_renaming_in_output(build_circuit, expected_present, expected_absent):
+    qc = QuantumCircuit(2, 2)
+    build_circuit(qc)
+    qc.measure([0, 1], [0, 1])
+    _assert_contents(compile_to_oq3(qc), expected_present, expected_absent)
+
+
+def test_compile_to_oq3_list_input(bell_circuit):
+    results = compile_to_oq3([bell_circuit, bell_circuit])
+    assert isinstance(results, list)
+    assert len(results) == 2
+    assert all("OPENQASM 3.0;" in r for r in results)
+
+
+@pytest.mark.parametrize(
+    "build_circuit,compile_kwargs,expected_present,expected_absent",
+    [
+        (
+            lambda bell: bell,
+            {"verbatim": True, "qubit_labels": [0, 1]},
+            ["#pragma braket verbatim", "box{"],
+            [],
+        ),
+        (
+            lambda bell: bell,
+            {"target": _bell_circuit_target(), "qubit_labels": [0, 1]},
+            ["OPENQASM 3.0;", "h ", "cnot ", "#pragma braket verbatim", "box{"],
+            [],
+        ),
+        (
+            lambda bell: _bell_with_verbatim_boxop(),
+            {"qubit_labels": [0, 1]},
+            ["h ", "cnot "],
+            [],
+        ),
+    ],
+    ids=["verbatim_flag", "target", "existing_verbatim_box"],
+)
+def test_compile_to_oq3_verbatim_wrapping_triggers(
+    bell_circuit, build_circuit, compile_kwargs, expected_present, expected_absent
+):
+    _assert_contents(
+        compile_to_oq3(build_circuit(bell_circuit), **compile_kwargs),
+        expected_present,
+        expected_absent,
+    )
+
+
+def test_compile_to_oq3_non_contiguous_qubit_labels(ghz_circuit):
+    _assert_contents(
+        compile_to_oq3(ghz_circuit, verbatim=True, qubit_labels=[0, 4, 7]),
+        ["$0", "$4", "$7"],
+        ["q["],
+    )
+
+
+@pytest.mark.parametrize(
+    "verbatim,qubit_labels,build_circuit",
+    [
+        (False, None, lambda qc: (qc.h(0), qc.cx(0, 1))),
+        (True, [0, 1], lambda qc: (qc.h(0), qc.cx(0, 1))),
+        (False, [0, 1], lambda qc: (qc.sx(0), qc.sdg(1), qc.cx(0, 1))),
+    ],
+    ids=["default", "verbatim", "renamed_gates"],
+)
+def test_compile_to_oq3_accepted_by_braket_simulator(sim, verbatim, qubit_labels, build_circuit):
+    qc = QuantumCircuit(2, 2)
+    build_circuit(qc)
+    qc.measure([0, 1], [0, 1])
+
+    oq3 = compile_to_oq3(qc, verbatim=verbatim, qubit_labels=qubit_labels)
+    result = sim.run(Program(source=oq3), shots=100)
+    assert result.result().measurements.shape == (100, 2)
+
+
+@pytest.mark.parametrize(
+    "source,expected_present,expected_absent",
+    [
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nqubit[2] q;\ncx q[0], q[1];\n",
+            ["cnot q[0], q[1];"],
+            ["cx "],
+        ),
+        (
+            "OPENQASM 3.0;\n// cx is a comment\ncx q[0], q[1];\n",
+            ["OPENQASM 3.0;", "// cx is a comment"],
+            [],
+        ),
+        (
+            "OPENQASM 3.0;\nrxx(0.5) q[0], q[1];\nrzz(1.0) q[0], q[1];\n",
+            ["xx(0.5)", "zz(1.0)"],
+            [],
+        ),
+    ],
+    ids=["gate_positions", "preserves_comments", "parametric_gates"],
+)
+def test_rename_gates(source, expected_present, expected_absent):
+    _assert_contents(_rename_gates(source), expected_present, expected_absent)
+
+
+@pytest.mark.parametrize(
+    "source,qubit_labels,expected_present,expected_absent,expect_unchanged",
+    [
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nqubit[2] q;\nh q[0];\ncnot q[0], q[1];\n",
+            [3, 7],
+            ["$3", "$7"],
+            ["qubit["],
+            False,
+        ),
+        (
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n",
+            None,
+            [],
+            [],
+            True,
+        ),
+    ],
+    ids=["declaration_and_refs", "noop_when_none"],
+)
+def test_remap_qubits(source, qubit_labels, expected_present, expected_absent, expect_unchanged):
+    result = _remap_qubits(source, qubit_labels)
+    if expect_unchanged:
+        assert result == source
+    _assert_contents(result, expected_present, expected_absent)
+
+
+@pytest.mark.parametrize(
+    "source,expected_present,expected_absent",
+    [
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nbox {\n  h $0;\n}\n",
+            ["#pragma braket verbatim\nbox{"],
+            [],
+        ),
+        (
+            "OPENQASM 3.0;\n  box {\n    h $0;\n  }\n",
+            ["#pragma braket verbatim\nbox{"],
+            ["  "],
+        ),
+        (
+            "OPENQASM 3.0;\nh q[0];\n",
+            ["OPENQASM 3.0;", "h q[0];"],
+            ["#pragma"],
+        ),
+        (
+            "OPENQASM 3.0;\ninput float[64] theta;\n",
+            ["float theta;"],
+            ["float[64]"],
+        ),
+    ],
+    ids=["inserts_pragma", "strips_indentation", "noop_without_box", "replaces_float64"],
+)
+def test_normalize_formatting(source, expected_present, expected_absent):
+    _assert_contents(_normalize_formatting(source), expected_present, expected_absent)
+
+
+@pytest.mark.parametrize(
+    "build_circuit,expected_creg_count,expected_num_clbits",
+    [
+        (
+            lambda: _consolidate_two_regs_circuit(),
+            1,
+            2,
+        ),
+        (
+            lambda: _single_reg_circuit(),
+            1,
+            2,
+        ),
+    ],
+    ids=["two_regs", "single_reg_noop"],
+)
+def test_consolidate_clbits_pass(build_circuit, expected_creg_count, expected_num_clbits):
+    result = PassManager([ConsolidateClbits()]).run(build_circuit())
+    assert len(result.cregs) == expected_creg_count
+    assert result.num_clbits == expected_num_clbits
+
+
+def test_wrap_in_verbatim_box_pass(bell_circuit):
+    result = PassManager([WrapInVerbatimBox()]).run(bell_circuit)
+    op_names = [instr.operation.name for instr in result.data]
+    assert "box" in op_names
+    assert op_names.count("measure") == 2
+
+    box_op = next(instr.operation for instr in result.data if instr.operation.name == "box")
+    assert box_op.label == "verbatim"
+    inner_ops = [instr.operation.name for instr in box_op.blocks[0].data]
+    assert "h" in inner_ops
+    assert "cx" in inner_ops
+
+
+def test_compile_to_oq3_raises_on_invalid_input():
+    with pytest.raises(TypeError):
+        compile_to_oq3("not a circuit")
+
+
+def test_compile_to_oq3_raises_on_conflicting_options(bell_circuit):
+    target = Target(num_qubits=2)
+    target.add_instruction(HGate(), name="h")
+    target.add_instruction(CXGate(), name="cx")
+    with pytest.raises(ValueError):
+        compile_to_oq3(bell_circuit, target=target, basis_gates=["h", "cx"])
+
+
+@pytest.mark.parametrize(
+    "build_circuit,compile_kwargs,expected_present,expected_absent",
+    [
+        (
+            lambda: _output_circuit(("c",), (2,)),
+            {},
+            ["output bit[2] c;"],
+            ["bit[2] b;"],
+        ),
+        (
+            lambda: _output_circuit(("first", "second"), (2, 1)),
+            {},
+            ["output bit[2] first;", "output bit[1] second;"],
+            [],
+        ),
+        (
+            lambda: _output_and_scratch_circuit(),
+            {},
+            ["output bit[2] first;", "bit[1] b;"],
+            ["scratch"],
+        ),
+        (
+            lambda: _output_circuit(("c",), (2,)),
+            {"verbatim": True, "qubit_labels": [0, 1]},
+            ["output bit[2] c;", "#pragma braket verbatim", "box{"],
+            [],
+        ),
+        (
+            lambda: _output_and_shadowed_plain_circuit(),
+            {},
+            ["output bit[1] b;", "bit[1] b0;"],
+            [],
+        ),
+    ],
+    ids=[
+        "single_output",
+        "multiple_outputs",
+        "output_with_plain_bits",
+        "output_survives_verbatim",
+        "plain_name_avoids_shadow",
+    ],
+)
+def test_compile_to_oq3_output_declarations(
+    build_circuit, compile_kwargs, expected_present, expected_absent
+):
+    _assert_contents(
+        compile_to_oq3(build_circuit(), **compile_kwargs), expected_present, expected_absent
+    )
+
+
+def test_compile_to_oq3_output_declaration_precedes_verbatim_box():
+    """Output declarations stay outside the verbatim box."""
+    qc = _output_circuit(("c",), (2,))
+    oq3 = compile_to_oq3(qc, verbatim=True, qubit_labels=[0, 1])
+    lines = oq3.split("\n")
+    output_idx = next(i for i, ln in enumerate(lines) if ln.startswith("output bit["))
+    box_idx = next(i for i, ln in enumerate(lines) if ln == "box{")
+    assert output_idx < box_idx
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [{}, {"braket_output_variables": {}}, {"unrelated": "value"}],
+    ids=["empty", "empty_output_map", "unrelated_key"],
+)
+def test_compile_to_oq3_no_output_metadata(bell_circuit, metadata):
+    """Without output metadata, no bit declaration is prefixed with `output`."""
+    bell_circuit.metadata = metadata
+    assert "output bit[" not in compile_to_oq3(bell_circuit)


### PR DESCRIPTION
## Summary
  
  Adds a new OpenQASM 3 output path that emits Qiskit circuits as OQ3 strings directly, bypassing the Braket SDK `Circuit` object. 
  
  ## What's new
  
  ### Public API (`providers/adapter.py`)
  
  | Function | Purpose |
  |----------|---------|
  | `to_oq3(circuit, ...)` | Serialize a compiled `QuantumCircuit` to a Braket-compatible OQ3 string |
  | `compile_to_oq3(circuits, ...)` | Orchestrate compilation + emission (accepts single circuit or iterable) |
  
  ### Transpiler passes (`providers/passes/oq3_processing.py`)
  
  - **`ConsolidateClbits`** — collapses plain classical bits into a single `"b"` register while preserving OpenQASM output-declared registers (identified via `circuit.metadata["braket_output_variables"]`). Falls back to `"b0"`, `"b1"`, ... if `"b"` shadows an output variable name. Mutates the DAG in place so the layout is preserved for downstream serialization.
  - **`WrapInVerbatimBox`** — wraps non-measurement operations in a verbatim `BoxOp`, preserving `dag.metadata`.
  
  ### Post-processing helpers (`providers/oq3_utils.py`)
  
  | Helper | Role |
  |--------|------|
  | `_post_process_oq3` | Orchestrator |
  | `_rename_gates` | Qiskit → Braket OQ3 gate names (`sx`→`v`, `cx`→`cnot`, `rxx`→`xx`, etc.). Only runs when the circuit contains Qiskit-specific names |
  | `_remap_qubits` | Handles both `qubit[N] q; ... q[i]` (default path) and `$N` (layout-aware path) → `$physical_label` |
  | `_normalize_formatting` | Strip indentation, `float[64]` → `float`, insert `#pragma braket verbatim`, `box {` → `box{`, remove empty lines |
  | `_restore_output_declaration` | Re-emit `output` keyword on registers listed in `braket_output_variables` metadata |
  
  ## Output shape by mode
  
  The behavior for various execution-mode taxonomies:
  
  | Trigger | Output | Service behavior |
  |---------|--------|------------------|
  | Default (no `target`/`pass_manager`/`verbatim`) | Bare gates, `qubit[N] q;` declaration | Service optimizes and executes |
  | `verbatim=True` | `#pragma braket verbatim` + `box{}` wrapping | Service executes as submitted |
  | `target=<Target>` or `pass_manager=<PM>` or `braket_device=<Device>` | Compiled to native gates, wrapped in verbatim | Service executes as submitted |
  
  ## Example output
  
  **Default:**
  
  OPENQASM 3.0;
  bit[2] b;
  qubit[2] q;
  h q[0];
  cnot q[0], q[1];
  b[0] = measure q[0];
  b[1] = measure q[1];
  
  **Verbatim (`verbatim=True, qubit_labels=[0, 1]`):**
  
  OPENQASM 3.0;
  bit[2] b;
  #pragma braket verbatim
  box{
  h $0;
  cnot $0, $1;
  }
  b[0] = measure $0;
  b[1] = measure $1;
  
  **With output variables (`metadata={"braket_output_variables": {"c": None}}`):**
  
  OPENQASM 3.0;
  output bit[2] c;
  qubit[2] q;
  h q[0];
  cnot q[0], q[1];
  c[0] = measure q[0];
  c[1] = measure q[1];
  
  ## Design notes
  
  - **Reuses `_compile()`** from `providers/compilation.py` — no duplicate compilation logic.
  - **Gate renaming is scoped** — only runs when the circuit actually contains Qiskit-specific gate names. Circuits compiled to device-native gates (via `target=`) skip this step.
  - **Layout preservation** — `ConsolidateClbits` mutates the DAG in place so `qasm3.dumps` continues to emit `$N` notation when the transpiler attached a layout.
  
  ## Testing
  
  - **45 tests** in `test/unit_tests/test_oq3.py` — parametrized across gate renaming, qubit remapping, verbatim triggers, output variable handling, and
  simulator round-tripping
  - **End-to-end verification** — outputs are parsed and executed by `braket.devices.LocalSimulator("braket_sv")`
  - **No regressions** — 256 tests in `test_oq3`, `test_adapter`, `test_adapter_to_braket_verbatim`, `test_basis_rotation_pass` pass locally
  
  ## Follow-ups (not in this PR)
  
  - **Next Step**: switch `BraketAwsBackend.run()`, `BraketLocalBackend.run()`, `BraketSampler.run()`, and `BraketEstimator.run()` to use `compile_to_oq3()`; implement the three validated execution modes (default / verbatim / native)