### PR TITLE
feat: add OQ3 post-processing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/pypi/v/qiskit-braket-provider.svg)](https://pypi.python.org/pypi/qiskit-braket-provider)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/qiskit-braket-provider.svg)](https://pypi.python.org/pypi/qiskit-braket-provider)
-[![Qiskit compatibility](https://img.shields.io/badge/Qiskit%20compatibility-%3E%3D2.0.0-blueviolet?logo=Qiskit)](https://github.com/Qiskit/qiskit/releases)
+[![Qiskit compatibility](https://img.shields.io/badge/Qiskit%20compatibility-%3E%3D2.2.0-blueviolet?logo=Qiskit)](https://github.com/Qiskit/qiskit/releases)
 [![Build status](https://github.com/amazon-braket/qiskit-braket-provider/actions/workflows/python-package.yml/badge.svg?branch=main)](https://github.com/amazon-braket/qiskit-braket-provider/actions/workflows/python-package.yml)
 [![Documentation Status](https://img.shields.io/readthedocs/qiskit-braket-provider?logo=read-the-docs)](https://qiskit-braket-provider.readthedocs.io)
 

--- a/qiskit_braket_provider/providers/adapter.py
+++ b/qiskit_braket_provider/providers/adapter.py
@@ -15,7 +15,6 @@ import qiskit.circuit.library as qiskit_gates
 import qiskit.quantum_info as qiskit_qi
 from qiskit import QuantumCircuit
 from qiskit.circuit import (
-    BoxOp,
     ControlledGate,
     Parameter,
     ParameterExpression,
@@ -37,6 +36,7 @@ from braket.default_simulator.openqasm.interpreter import Interpreter
 from braket.devices import Device
 from braket.ir.openqasm import Program
 from braket.parametric import FreeParameter, FreeParameterExpression, Parameterizable
+from qiskit_braket_provider.providers.braket_annotations import BraketVerbatimBox
 from qiskit_braket_provider.providers.compilation import (
     _CompilationContext,  # ruff:ignore[unused-import]
     _compile,
@@ -647,9 +647,7 @@ def to_qiskit(
             case compiler_directives.StartVerbatimBox(), _:
                 continue
             case compiler_directives.EndVerbatimBox(), _:
-                qiskit_circuit = qiskit_circuit.compose(
-                    BoxOp(verbatim_buffer, label=_BRAKET_VERBATIM_BOX_NAME)
-                )
+                qiskit_circuit = qiskit_circuit.compose(BraketVerbatimBox(verbatim_buffer))
                 verbatim_buffer = None
             case _, False:
                 verbatim_buffer.append(gate, target)

--- a/qiskit_braket_provider/providers/braket_annotations.py
+++ b/qiskit_braket_provider/providers/braket_annotations.py
@@ -1,0 +1,63 @@
+"""Braket-verbatim annotation and box-op infrastructure for OpenQASM 3 emission.
+
+This module hosts the Qiskit :class:`~qiskit.circuit.annotation.Annotation` and
+:class:`~qiskit.circuit.BoxOp` machinery used to mark verbatim blocks in Qiskit
+circuits so that ``qasm3.dumps`` emits Braket's ``#pragma braket verbatim``
+directive.
+"""
+
+import re
+
+from qiskit.circuit import BoxOp, QuantumCircuit
+from qiskit.circuit.annotation import Annotation, OpenQASM3Serializer
+
+from qiskit_braket_provider.providers.gate_mappings import (
+    _BRAKET_VERBATIM_BOX_NAME,
+    _BRAKET_VERBATIM_PRAGMA_PAYLOAD,
+)
+
+_BRAKET_VERBATIM_ANNOTATION_LINE = re.compile(r"^@braket_verbatim\s+pragma\s+braket\s+verbatim\s*$")
+
+
+class BraketVerbatim(Annotation):
+    """Marks a ``BoxOp`` as a Braket verbatim block for OpenQASM 3 emission."""
+
+    namespace = "braket_verbatim"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, BraketVerbatim)
+
+    def __hash__(self) -> int:
+        return hash(BraketVerbatim)
+
+
+class BraketVerbatimSerializer(OpenQASM3Serializer):
+    """Serializes :class:`BraketVerbatim` as ``pragma braket verbatim``."""
+
+    def dump(self, annotation: Annotation) -> str:
+        if isinstance(annotation, BraketVerbatim):
+            return _BRAKET_VERBATIM_PRAGMA_PAYLOAD
+        raise NotImplementedError  # pragma: no cover
+
+    def load(self, _namespace: str, _payload: str) -> Annotation:
+        raise NotImplementedError  # pragma: no cover
+
+
+_BRAKET_ANNOTATION_HANDLERS: dict[str, OpenQASM3Serializer] = {
+    BraketVerbatim.namespace: BraketVerbatimSerializer(),
+}
+
+
+class BraketVerbatimBox(BoxOp):
+    """A ``BoxOp`` pre-configured as a Braket verbatim block.
+
+    Attaches :class:`BraketVerbatim` and sets ``label=_BRAKET_VERBATIM_BOX_NAME``
+    (overridable via ``label``) so ``qasm3.dumps`` emits the verbatim directive.
+    """
+
+    def __init__(self, body: QuantumCircuit, label: str = _BRAKET_VERBATIM_BOX_NAME) -> None:
+        super().__init__(
+            body,
+            label=label,
+            annotations=[BraketVerbatim()],
+        )

--- a/qiskit_braket_provider/providers/gate_mappings.py
+++ b/qiskit_braket_provider/providers/gate_mappings.py
@@ -215,6 +215,10 @@ _BRAKET_GATE_NAME_TO_QISKIT_GATE: dict[str, QiskitInstruction | None] = {
 
 _BRAKET_VERBATIM_BOX_NAME = "verbatim"
 
+_BRAKET_VERBATIM_PRAGMA_PAYLOAD = "pragma braket verbatim"
+
+_BRAKET_VERBATIM_PRAGMA_LINE = f"#{_BRAKET_VERBATIM_PRAGMA_PAYLOAD}"
+
 _OUTPUT_VARIABLES_KEY = "braket_output_variables"
 
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
@@ -291,3 +295,135 @@ def _reverse_endianness(matrix: np.ndarray) -> np.ndarray:
         matrix.reshape([2] * n_q * 2),
         list(range(n_q))[::-1] + list(range(n_q, 2 * n_q))[::-1],
     ).reshape((2**n_q, 2**n_q))
+
+
+class BraketPhaseShiftGate(qiskit_gates.PhaseGate):
+    """Qiskit ``PhaseGate`` rendered as Braket's ``phaseshift`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "phaseshift"
+
+
+class BraketCNotGate(qiskit_gates.CXGate):
+    """Qiskit ``CXGate`` rendered as Braket's ``cnot`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "cnot"
+
+
+class BraketTiGate(qiskit_gates.TdgGate):
+    """Qiskit ``TdgGate`` rendered as Braket's ``ti`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "ti"
+
+
+class BraketSiGate(qiskit_gates.SdgGate):
+    """Qiskit ``SdgGate`` rendered as Braket's ``si`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "si"
+
+
+class BraketVGate(qiskit_gates.SXGate):
+    """Qiskit ``SXGate`` rendered as Braket's ``v`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "v"
+
+
+class BraketViGate(qiskit_gates.SXdgGate):
+    """Qiskit ``SXdgGate`` rendered as Braket's ``vi`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "vi"
+
+
+class BraketXXGate(qiskit_gates.RXXGate):
+    """Qiskit ``RXXGate`` rendered as Braket's ``xx`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "xx"
+
+
+class BraketYYGate(qiskit_gates.RYYGate):
+    """Qiskit ``RYYGate`` rendered as Braket's ``yy`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "yy"
+
+
+class BraketZZGate(qiskit_gates.RZZGate):
+    """Qiskit ``RZZGate`` rendered as Braket's ``zz`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "zz"
+
+
+class BraketIGate(qiskit_gates.IGate):
+    """Qiskit ``IGate`` rendered as Braket's ``i`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "i"
+
+
+class BraketCCNotGate(qiskit_gates.CCXGate):
+    """Qiskit ``CCXGate`` rendered as Braket's ``ccnot`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "ccnot"
+
+
+class BraketCPhaseShiftGate(qiskit_gates.CPhaseGate):
+    """Qiskit ``CPhaseGate`` rendered as Braket's ``cphaseshift`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "cphaseshift"
+
+
+class BraketPRxGate(qiskit_gates.RGate):
+    """Qiskit ``RGate`` rendered as Braket's ``prx`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "prx"
+
+
+class BraketGPhaseGate(qiskit_gates.GlobalPhaseGate):
+    """Qiskit ``GlobalPhaseGate`` rendered as Braket's ``gphase`` in OpenQASM 3."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = "gphase"
+
+
+_QISKIT_TO_BRAKET_SHIM: dict[type, type] = {
+    qiskit_gates.PhaseGate: BraketPhaseShiftGate,
+    qiskit_gates.CXGate: BraketCNotGate,
+    qiskit_gates.TdgGate: BraketTiGate,
+    qiskit_gates.SdgGate: BraketSiGate,
+    qiskit_gates.SXGate: BraketVGate,
+    qiskit_gates.SXdgGate: BraketViGate,
+    qiskit_gates.RXXGate: BraketXXGate,
+    qiskit_gates.RYYGate: BraketYYGate,
+    qiskit_gates.RZZGate: BraketZZGate,
+    qiskit_gates.IGate: BraketIGate,
+    qiskit_gates.CCXGate: BraketCCNotGate,
+    qiskit_gates.CPhaseGate: BraketCPhaseShiftGate,
+    qiskit_gates.RGate: BraketPRxGate,
+    qiskit_gates.GlobalPhaseGate: BraketGPhaseGate,
+}
+
+_SHIM_CLASSES: frozenset[type] = frozenset(_QISKIT_TO_BRAKET_SHIM.values())

--- a/qiskit_braket_provider/providers/passes/__init__.py
+++ b/qiskit_braket_provider/providers/passes/__init__.py
@@ -3,6 +3,7 @@
 from .basis_rotation_pass import AddBasisRotationAndMeasurement as AddBasisRotationAndMeasurement
 from .braket_formatting_passes import ConsolidateClbits as ConsolidateClbits
 from .braket_formatting_passes import MoveMeasurementsToEnd as MoveMeasurementsToEnd
+from .braket_formatting_passes import RenameGates as RenameGates
 from .braket_formatting_passes import WrapInVerbatimBox as WrapInVerbatimBox
 from .verbatim_passes import ExtractVerbatimBoxes as ExtractVerbatimBoxes
 from .verbatim_passes import RestoreVerbatimBoxes as RestoreVerbatimBoxes

--- a/qiskit_braket_provider/providers/passes/braket_formatting_passes.py
+++ b/qiskit_braket_provider/providers/passes/braket_formatting_passes.py
@@ -1,24 +1,27 @@
-"""Transpiler passes for preparing circuits for Braket-compatible serialization."""
+"""Transpiler passes and string post-processing helpers for Braket-compatible OQ3 emission."""
 
-from qiskit.circuit import BoxOp, ClassicalRegister, Measure, QuantumCircuit
+import re
+from collections.abc import Iterable, Sequence
+
+from qiskit.circuit import ClassicalRegister, Instruction, Measure, QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 
+from qiskit_braket_provider.providers.braket_annotations import (
+    _BRAKET_VERBATIM_ANNOTATION_LINE,
+    BraketVerbatimBox,
+)
 from qiskit_braket_provider.providers.gate_mappings import (
-    _BRAKET_VERBATIM_BOX_NAME,
+    _BRAKET_VERBATIM_PRAGMA_LINE,
     _OUTPUT_VARIABLES_KEY,
+    _QISKIT_TO_BRAKET_SHIM,
+    _SHIM_CLASSES,
 )
 
+_QUBIT_DECL_RE = re.compile(r"^qubit\[(\d+)\]\s+(\w+);\n?", re.MULTILINE)
 
-def _plain_register_name(taken: set) -> str:
-    """Return ``"b"``, or the first ``"b<i>"`` not shadowed by an output variable name."""
-    if "b" not in taken:
-        return "b"
-    i = 0
-    while f"b{i}" in taken:
-        i += 1
-    return f"b{i}"
+_PHYSICAL_QUBIT_RE = re.compile(r"\$(\d+)")
 
 
 class ConsolidateClbits(TransformationPass):
@@ -55,6 +58,16 @@ class ConsolidateClbits(TransformationPass):
         if plain:
             dag.add_creg(ClassicalRegister(name=_plain_register_name(output_names), bits=plain))
         return dag
+
+
+def _plain_register_name(taken: set) -> str:
+    """Return ``"b"``, or the first ``"b<i>"`` not shadowed by an output variable name."""
+    if "b" not in taken:
+        return "b"
+    i = 0
+    while f"b{i}" in taken:
+        i += 1
+    return f"b{i}"
 
 
 class MoveMeasurementsToEnd(TransformationPass):
@@ -124,9 +137,169 @@ class WrapInVerbatimBox(TransformationPass):
                 inner.append(instr.operation, instr.qubits, instr.clbits)
 
         result = QuantumCircuit(*circuit.qregs, *circuit.cregs)
-        result.append(BoxOp(inner, label=_BRAKET_VERBATIM_BOX_NAME), result.qubits, result.clbits)
+        result.append(BraketVerbatimBox(inner), result.qubits, result.clbits)
         for instr in trailing_measurements:
             result.append(instr.operation, instr.qubits, instr.clbits)
 
         result.metadata = dag.metadata
         return circuit_to_dag(result)
+
+
+class RenameGates(TransformationPass):
+    """Substitute Qiskit gates with Braket-named shim subclasses.
+
+    ``qasm3.dumps`` reads ``Gate.name`` for serialization, so replacing e.g.
+    ``CXGate`` with its shim (same semantics, ``name = "cnot"``) makes the
+    serializer emit the Braket-native gate name. Recurses into
+    ``.blocks``-carrying ops so nested gates are renamed too.
+    """
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Substitute renameable Qiskit gates with their shim subclasses."""
+        for node in dag.op_nodes():
+            shim_cls = _shim_class_for(node.op)
+            if shim_cls is not None:
+                dag.substitute_node(node, _construct_shim(node.op, shim_cls))
+            elif getattr(node.op, "blocks", None):
+                dag.substitute_node(node, _rename_gates_in_block_op(node.op))
+        return dag
+
+
+def _shim_class_for(op: Instruction) -> type | None:
+    """Return the shim class for ``op``, or ``None`` if no shim applies.
+
+    Walks ``type(op).__mro__`` so ops that are Qiskit-generated singleton
+    subclasses (e.g. ``_SingletonCXGate`` for ``CXGate``) match their mapped
+    parent. Returns ``None`` if ``op`` is already a shim instance.
+    """
+    for cls in type(op).__mro__:
+        if cls in _SHIM_CLASSES:
+            return None
+        if cls in _QISKIT_TO_BRAKET_SHIM:
+            return _QISKIT_TO_BRAKET_SHIM[cls]
+    return None
+
+
+def _construct_shim(op: Instruction, shim_cls: type) -> Instruction:
+    """Construct a shim instance mirroring ``op``'s parameters and label.
+
+    Passing ``label`` at construction time (rather than mutating afterwards)
+    yields a fresh, non-singleton instance from Qiskit's singleton machinery.
+    """
+    if op.label is not None:
+        return shim_cls(*op.params, label=op.label)
+    return shim_cls(*op.params)
+
+
+def _rename_gates_in_circuit(circuit: QuantumCircuit) -> QuantumCircuit:
+    """Return a new circuit with each renameable Qiskit gate replaced by its shim.
+
+    Recurses into ``.blocks``-carrying ops (``IfElseOp`` / ``BoxOp`` / ...)
+    at arbitrary nesting depth, so gates buried inside nested control-flow
+    blocks are also renamed. Returns a fresh ``QuantumCircuit`` instead of
+    mutating in place to avoid Qiskit's shared-block invariants.
+    """
+    new_circuit = circuit.copy_empty_like()
+    for inst in circuit.data:
+        op = inst.operation
+        shim_cls = _shim_class_for(op)
+        if shim_cls is not None:
+            new_circuit.append(_construct_shim(op, shim_cls), inst.qubits, inst.clbits)
+        elif getattr(op, "blocks", None):
+            new_circuit.append(_rename_gates_in_block_op(op), inst.qubits, inst.clbits)
+        else:
+            new_circuit.append(op, inst.qubits, inst.clbits)
+    return new_circuit
+
+
+def _rename_gates_in_block_op(op: Instruction) -> Instruction:
+    """Return a copy of a ``.blocks``-carrying op with each block's gates renamed."""
+    return op.replace_blocks([_rename_gates_in_circuit(block) for block in op.blocks])
+
+
+def _remap_qubits(oq3_source: str, qubit_labels: Sequence[int] | None) -> str:
+    """Replace qubit references with physical qubit notation.
+
+    Handles two cases produced by ``qasm3.dumps()``:
+
+    1. **Layout-aware output** (``$N`` notation, no ``qubit[N] q;`` declaration):
+       when the circuit's ``layout`` property is set, Qiskit emits physical
+       qubit references directly. Remap ``$N`` → ``$qubit_labels[N]``.
+
+    2. **Virtual register output** (``qubit[N] q; ... q[i]``): when no layout
+       is attached, Qiskit falls back to virtual register syntax. Remove the
+       ``qubit[N] q;`` declaration and remap ``q[i]`` → ``$qubit_labels[i]``.
+       This path primarily serves Qiskit circuits submitted with
+       ``verbatim=True``, where physical ``$N`` output is required but no
+       Qiskit ``.layout`` has been attached to the circuit.
+
+    Raises:
+        ValueError: If the source contains more than one ``qubit[N] ...;``
+            declaration. Braket supports at most one quantum register.
+        ValueError: If ``len(qubit_labels)`` does not match the ``N`` declared
+            in the ``qubit[N] q;`` register (virtual-register case), or if a
+            physical qubit reference ``$N`` in the source is out of range for
+            ``qubit_labels`` (layout-aware case).
+    """
+    declarations = _QUBIT_DECL_RE.findall(oq3_source)
+    if len(declarations) > 1:
+        raise ValueError(
+            f"Braket does not support multiple quantum registers; "
+            f"got {len(declarations)}: {[name for _, name in declarations]}."
+        )
+
+    if not qubit_labels:
+        return oq3_source
+
+    match = _QUBIT_DECL_RE.search(oq3_source)
+    if match:
+        num_qubits = int(match.group(1))
+        reg_name = match.group(2)
+        if len(qubit_labels) != num_qubits:
+            raise ValueError(
+                f"qubit_labels length ({len(qubit_labels)}) does not match "
+                f"the circuit's qubit count ({num_qubits})."
+            )
+        oq3_source = _QUBIT_DECL_RE.sub("", oq3_source, count=1)
+        for i, label in enumerate(qubit_labels):
+            oq3_source = oq3_source.replace(f"{reg_name}[{i}]", f"${label}")
+        return oq3_source
+
+    referenced = [int(m) for m in _PHYSICAL_QUBIT_RE.findall(oq3_source)]
+    if referenced and max(referenced) >= len(qubit_labels):
+        raise ValueError(
+            f"qubit_labels length ({len(qubit_labels)}) is too short for "
+            f"physical qubit reference ${max(referenced)} in the source."
+        )
+    # Rewrite each virtual physical-qubit reference $i to $qubit_labels[i]
+    # (the caller-provided physical qubit for that position).
+    return _PHYSICAL_QUBIT_RE.sub(lambda m: f"${qubit_labels[int(m.group(1))]}", oq3_source)
+
+
+def _normalize_formatting(oq3_source: str, output_names: Iterable[str] = ()) -> str:
+    """Normalize OQ3 formatting to match Braket service conventions.
+
+    - Strips leading indentation from all lines
+    - Replaces ``float[64]`` with ``float``
+    - Rewrites the Braket-verbatim annotation prefix emitted by ``qasm3.dumps``
+      to Braket's canonical ``#pragma braket verbatim`` directive.
+    - Restores ``output`` keyword on registers listed in ``output_names``
+    - Removes empty lines
+    """
+    output_set = set(output_names)
+    lines: list[str] = []
+    for raw_line in oq3_source.split("\n"):
+        line = raw_line.lstrip().replace("float[64]", "float")
+        if _BRAKET_VERBATIM_ANNOTATION_LINE.match(line):
+            lines.append(_BRAKET_VERBATIM_PRAGMA_LINE)
+            continue
+        lines.append(_restore_output_declaration(line, output_set))
+    return "\n".join(line for line in lines if line != "")
+
+
+def _restore_output_declaration(line: str, output_names: set[str]) -> str:
+    """Re-add the ``output`` keyword to bit declarations whose name is in ``output_names``."""
+    if not line.startswith("bit["):
+        return line
+    name = line.removesuffix(";").rpartition(" ")[2]
+    return f"output {line}" if name in output_names else line

--- a/qiskit_braket_provider/providers/qasm_context.py
+++ b/qiskit_braket_provider/providers/qasm_context.py
@@ -59,6 +59,7 @@ from braket.default_simulator.openqasm.program_context import (
 )
 from braket.ir.jaqcd import AdjointGradient
 from braket.ir.jaqcd.program_v1 import Results
+from qiskit_braket_provider.providers.braket_annotations import BraketVerbatimBox
 from qiskit_braket_provider.providers.gate_mappings import (
     _BRAKET_GATE_NAME_TO_QISKIT_GATE,
     _BRAKET_VERBATIM_BOX_NAME,
@@ -429,7 +430,11 @@ class _QiskitProgramContext(AbstractProgramContext):
             body = self._circuit_stack.pop()
             parent = self._active_circuit
             self._extend_bits(parent, body)
-            parent.append(BoxOp(body, label=self._verbatim_box_name), parent.qubits, parent.clbits)
+            parent.append(
+                BraketVerbatimBox(body, label=self._verbatim_box_name),
+                parent.qubits,
+                parent.clbits,
+            )
             self._in_verbatim_box = False
 
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi>=2021.5.30
-qiskit>=2.0.0,<3.0.0
+qiskit>=2.2.0,<3.0.0
 qiskit-ionq>=1.0.0,<2.0.0
 amazon-braket-sdk>=1.123.0
 amazon-braket-default-simulator>=1.40.1

--- a/test/unit_tests/test_adapter_to_qiskit_verbatim.py
+++ b/test/unit_tests/test_adapter_to_qiskit_verbatim.py
@@ -11,10 +11,9 @@ from braket.default_simulator.openqasm.interpreter import VerbatimBoxDelimiter
 from braket.default_simulator.openqasm.parser.openqasm_ast import BitType, Identifier
 from braket.ir.openqasm import Program
 from qiskit_braket_provider import to_qiskit
-from qiskit_braket_provider.providers.adapter import (
-    _BRAKET_VERBATIM_BOX_NAME,
-    _QiskitProgramContext,
-)
+from qiskit_braket_provider.providers.adapter import _QiskitProgramContext
+from qiskit_braket_provider.providers.braket_annotations import BraketVerbatimBox
+from qiskit_braket_provider.providers.gate_mappings import _BRAKET_VERBATIM_BOX_NAME
 
 
 def _get_box_ops(qiskit_circuit: QuantumCircuit) -> list[CircuitInstruction]:
@@ -369,7 +368,7 @@ def test_braket_to_qiskit_verbatim_instruciton():
     boxed = QuantumCircuit(
         2,
     )
-    boxed = boxed.compose(BoxOp(circuit, label=_BRAKET_VERBATIM_BOX_NAME))
+    boxed = boxed.compose(BraketVerbatimBox(circuit))
     assert to_qiskit(test, add_measurements=False) == boxed
 
 

--- a/test/unit_tests/test_braket_formatting_passes.py
+++ b/test/unit_tests/test_braket_formatting_passes.py
@@ -3,15 +3,31 @@
 from collections.abc import Callable
 
 import pytest
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, qasm3
 from qiskit.circuit import BoxOp, ClassicalRegister, Clbit, IfElseOp, QuantumRegister
+from qiskit.circuit.library import CXGate, GlobalPhaseGate, PhaseGate, RGate, RXXGate
 from qiskit.transpiler import PassManager
 
-from qiskit_braket_provider.providers.gate_mappings import _BRAKET_VERBATIM_BOX_NAME
+from qiskit_braket_provider.providers.braket_annotations import (
+    _BRAKET_ANNOTATION_HANDLERS,
+    BraketVerbatim,
+    BraketVerbatimBox,
+    BraketVerbatimSerializer,
+)
+from qiskit_braket_provider.providers.gate_mappings import (
+    _BRAKET_VERBATIM_BOX_NAME,
+    _QISKIT_TO_BRAKET_SHIM,
+)
 from qiskit_braket_provider.providers.passes import (
     ConsolidateClbits,
     MoveMeasurementsToEnd,
+    RenameGates,
     WrapInVerbatimBox,
+)
+from qiskit_braket_provider.providers.passes.braket_formatting_passes import (
+    _normalize_formatting,
+    _remap_qubits,
+    _shim_class_for,
 )
 
 
@@ -158,8 +174,121 @@ def _if_else_circuit_for_verbatim() -> QuantumCircuit:
     return qc
 
 
+def _build_cx_and_p() -> QuantumCircuit:
+    qc = QuantumCircuit(2)
+    qc.cx(0, 1)
+    qc.p(0.5, 0)
+    return qc
+
+
+def _build_rxx_and_r() -> QuantumCircuit:
+    qc = QuantumCircuit(2)
+    qc.rxx(0.3, 0, 1)
+    qc.r(0.7, 0.1, 0)
+    return qc
+
+
+def _build_cx_only_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(2)
+    qc.cx(0, 1)
+    return qc
+
+
+def _build_native_gates_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.rx(0.5, 1)
+    return qc
+
+
+def _build_already_shimmed_circuit() -> QuantumCircuit:
+    return PassManager([RenameGates()]).run(_build_cx_only_circuit())
+
+
+def _build_if_else_body_with_cx_and_p() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.measure(0, 0)
+    with qc.if_test((qc.clbits[0], 1)):
+        qc.cx(0, 1)
+        qc.p(0.5, 1)
+    return qc
+
+
+def _build_box_body_with_cx_and_p() -> QuantumCircuit:
+    inner = QuantumCircuit(2)
+    inner.cx(0, 1)
+    inner.p(0.5, 0)
+    outer = QuantumCircuit(2)
+    outer.append(BraketVerbatimBox(inner), [0, 1])
+    return outer
+
+
+def _build_bell_with_rxx() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.rxx(0.5, 0, 1)
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+def _build_bell() -> QuantumCircuit:
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    return qc
+
+
+def _build_plain_box() -> QuantumCircuit:
+    inner = QuantumCircuit(2)
+    inner.h(0)
+    inner.cx(0, 1)
+    qc = QuantumCircuit(2)
+    qc.append(BoxOp(inner, label="plain"), [0, 1])
+    return qc
+
+
 def _get_if_else(circuit: QuantumCircuit) -> IfElseOp:
     return next(instr.operation for instr in circuit.data if isinstance(instr.operation, IfElseOp))
+
+
+def _if_else_body_ops(circuit: QuantumCircuit) -> list:
+    """Extract the true-branch ops from an IfElseOp inside ``circuit``."""
+    op = next(instr.operation for instr in circuit.data if isinstance(instr.operation, IfElseOp))
+    return list(op.blocks[0].data)
+
+
+def _box_body_ops(circuit: QuantumCircuit) -> list:
+    """Extract the body ops from a BoxOp inside ``circuit``."""
+    op = next(instr.operation for instr in circuit.data if isinstance(instr.operation, BoxOp))
+    return list(op.blocks[0].data)
+
+
+def _assert_contents(source: str, expected_present: list[str], expected_absent: list[str]) -> None:
+    for s in expected_present:
+        assert s in source
+    for s in expected_absent:
+        assert s not in source
+
+
+def _dumps_with_passes(circuit: QuantumCircuit, *, basis_gates: list[str], verbatim: bool) -> str:
+    """Run the passes and dump to OQ3"""
+    pm = PassManager()
+    pm.append(ConsolidateClbits())
+    pm.append(MoveMeasurementsToEnd())
+    if verbatim:
+        pm.append(WrapInVerbatimBox())
+    pm.append(RenameGates())
+    compiled = pm.run(circuit)
+    return qasm3.dumps(
+        compiled,
+        includes=[],
+        basis_gates=basis_gates,
+        disable_constants=True,
+        annotation_handlers=_BRAKET_ANNOTATION_HANDLERS,
+    )
 
 
 @pytest.mark.parametrize(
@@ -270,13 +399,15 @@ def test_wrap_in_verbatim_box(
 
     top_level_boxes = [instr for instr in result.data if isinstance(instr.operation, BoxOp)]
     assert len(top_level_boxes) == 1
-    assert top_level_boxes[0].operation.label == _BRAKET_VERBATIM_BOX_NAME
+    box_op = top_level_boxes[0].operation
+    assert box_op.label == _BRAKET_VERBATIM_BOX_NAME
+    assert any(isinstance(a, BraketVerbatim) for a in box_op.annotations)
 
     op_names = [instr.operation.name for instr in result.data]
     box_idx = op_names.index("box")
     assert op_names[box_idx + 1 :] == expected_trailing_ops
 
-    inner_ops = [instr.operation.name for instr in top_level_boxes[0].operation.blocks[0].data]
+    inner_ops = [instr.operation.name for instr in box_op.blocks[0].data]
     assert inner_ops == expected_inner_ops
     assert result.metadata == expected_metadata
 
@@ -306,6 +437,364 @@ def test_wrap_in_verbatim_box_empty_circuit(circuit: QuantumCircuit) -> None:
     assert len(top_level_boxes) == 1
     box_instr = top_level_boxes[0]
     assert box_instr.operation.label == _BRAKET_VERBATIM_BOX_NAME
+    assert any(isinstance(a, BraketVerbatim) for a in box_instr.operation.annotations)
     assert list(box_instr.qubits) == list(circuit.qubits)
     assert list(box_instr.clbits) == list(circuit.clbits)
     assert list(box_instr.operation.blocks[0].data) == []
+
+
+@pytest.mark.parametrize(
+    "build_circuit,expected_ops,expected_names",
+    [
+        (
+            _build_cx_and_p,
+            [_QISKIT_TO_BRAKET_SHIM[CXGate], _QISKIT_TO_BRAKET_SHIM[PhaseGate]],
+            ["cnot", "phaseshift"],
+        ),
+        (
+            _build_rxx_and_r,
+            [_QISKIT_TO_BRAKET_SHIM[RXXGate], _QISKIT_TO_BRAKET_SHIM[RGate]],
+            ["xx", "prx"],
+        ),
+    ],
+    ids=["cx_and_p", "rxx_and_r"],
+)
+def test_rename_gates_substitutes_shims(
+    build_circuit: Callable, expected_ops: list[type], expected_names: list[str]
+) -> None:
+    """Each Qiskit gate is replaced with its shim, preserving parameters."""
+    result = PassManager([RenameGates()]).run(build_circuit())
+    ops = [instr.operation for instr in result.data]
+    for op, expected_cls in zip(ops, expected_ops, strict=True):
+        assert isinstance(op, expected_cls)
+    assert [op.name for op in ops] == expected_names
+
+
+@pytest.mark.parametrize(
+    "build_circuit,expected_names",
+    [
+        (_build_native_gates_circuit, ["h", "rx"]),
+        (_build_already_shimmed_circuit, ["cnot"]),
+    ],
+    ids=["already_native", "already_shimmed"],
+)
+def test_rename_gates_is_noop_when_nothing_to_rename(
+    build_circuit: Callable, expected_names: list[str]
+) -> None:
+    """Gates already using Braket-native names (or already shimmed) pass through unchanged."""
+    result = PassManager([RenameGates()]).run(build_circuit())
+    assert [instr.operation.name for instr in result.data] == expected_names
+
+
+@pytest.mark.parametrize(
+    "build_circuit,extract_body_ops",
+    [
+        (_build_if_else_body_with_cx_and_p, _if_else_body_ops),
+        (_build_box_body_with_cx_and_p, _box_body_ops),
+    ],
+    ids=["if_else_body", "box_body"],
+)
+def test_rename_gates_recurses_into_block_bodies(
+    build_circuit: Callable, extract_body_ops: Callable
+) -> None:
+    """Gates nested inside IfElseOp or BoxOp block bodies are renamed too."""
+    result = PassManager([RenameGates()]).run(build_circuit())
+    body_ops = extract_body_ops(result)
+    assert isinstance(body_ops[0].operation, _QISKIT_TO_BRAKET_SHIM[CXGate])
+    assert isinstance(body_ops[1].operation, _QISKIT_TO_BRAKET_SHIM[PhaseGate])
+
+
+def test_rename_gates_recurses_into_deeply_nested_blocks() -> None:
+    """Recursion handles BoxOp nested inside IfElseOp's true-branch body."""
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.measure(0, 0)
+    with qc.if_test((qc.clbits[0], 1)):
+        inner = QuantumCircuit(2)
+        inner.cx(0, 1)
+        inner.p(0.5, 0)
+        qc.append(BoxOp(inner, label="nested"), [0, 1])
+
+    result = PassManager([RenameGates()]).run(qc)
+    if_else = next(i.operation for i in result.data if isinstance(i.operation, IfElseOp))
+    inner_box = next(i.operation for i in if_else.blocks[0].data if isinstance(i.operation, BoxOp))
+    ops = list(inner_box.blocks[0].data)
+    assert isinstance(ops[0].operation, _QISKIT_TO_BRAKET_SHIM[CXGate])
+    assert isinstance(ops[1].operation, _QISKIT_TO_BRAKET_SHIM[PhaseGate])
+
+
+def test_rename_gates_preserves_label() -> None:
+    """A user-set ``label`` on the original gate survives the shim substitution."""
+    qc = QuantumCircuit(2)
+    labeled = CXGate(label="my_cx")
+    qc.append(labeled, [0, 1])
+    result = PassManager([RenameGates()]).run(qc)
+    shimmed = result.data[0].operation
+    assert isinstance(shimmed, _QISKIT_TO_BRAKET_SHIM[CXGate])
+    assert isinstance(shimmed, CXGate)  # narrow for type-checker attribute access below
+    assert shimmed.label == "my_cx"
+
+
+def test_shim_class_for_returns_none_for_already_shimmed_op() -> None:
+    """The idempotence guard: a shim instance is recognised via its MRO and skipped.
+
+    Called directly because ``PassManager``'s ``dag_to_circuit`` round-trip
+    strips shim-gate identity, so the pass never sees a shim in practice.
+    """
+    assert _shim_class_for(_QISKIT_TO_BRAKET_SHIM[CXGate]()) is None
+
+
+def test_rename_gates_preserves_parameters() -> None:
+    """Shim retains the original gate's numeric parameters."""
+    qc = QuantumCircuit(2)
+    qc.rxx(1.5, 0, 1)
+    qc.p(0.75, 0)
+    result = PassManager([RenameGates()]).run(qc)
+    ops = [instr.operation for instr in result.data]
+    assert ops[0].params == [1.5]
+    assert ops[1].params == [0.75]
+
+
+def test_rename_gates_covers_every_shim() -> None:
+    """Every Qiskit gate registered in the shim map is renamed to its Braket name."""
+    qc = QuantumCircuit(3)
+    qc.cx(0, 1)
+    qc.p(0.1, 0)
+    qc.tdg(0)
+    qc.sdg(0)
+    qc.sx(0)
+    qc.sxdg(0)
+    qc.rxx(0.2, 0, 1)
+    qc.ryy(0.3, 0, 1)
+    qc.rzz(0.4, 0, 1)
+    qc.id(0)
+    qc.ccx(0, 1, 2)
+    qc.cp(0.5, 0, 1)
+    qc.r(0.6, 0.7, 0)
+    qc.append(GlobalPhaseGate(0.8), [])
+
+    result = PassManager([RenameGates()]).run(qc)
+    for instr in result.data:
+        expected_shim = next(
+            shim
+            for qiskit_cls, shim in _QISKIT_TO_BRAKET_SHIM.items()
+            if isinstance(instr.operation, qiskit_cls)
+        )
+        assert isinstance(instr.operation, expected_shim)
+
+
+def test_braket_verbatim_serializer_dumps_pragma_payload() -> None:
+    """dump() emits the pragma-verbatim payload for a BraketVerbatim annotation."""
+    assert BraketVerbatimSerializer().dump(BraketVerbatim()) == "pragma braket verbatim"
+
+
+def test_braket_verbatim_annotations_are_value_equal() -> None:
+    """Any two ``BraketVerbatim`` instances compare equal and share a hash.
+
+    Required for ``BoxOp.__eq__`` on Qiskit versions that compare annotations
+    by value: hand-built and library-built verbatim boxes must round-trip
+    through equality checks (e.g. in tests that assert ``to_qiskit(...) == qc``).
+    """
+    a, b = BraketVerbatim(), BraketVerbatim()
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != BraketVerbatim.namespace
+
+
+@pytest.mark.parametrize(
+    "label_kwarg,expected_label",
+    [({}, _BRAKET_VERBATIM_BOX_NAME), ({"label": "custom_verbatim"}, "custom_verbatim")],
+    ids=["default_label", "custom_label"],
+)
+def test_braket_verbatim_box_label_and_annotation(label_kwarg: dict, expected_label: str) -> None:
+    """BraketVerbatimBox always attaches the annotation; label defaults or accepts an override."""
+    box = BraketVerbatimBox(QuantumCircuit(2), **label_kwarg)
+    assert box.label == expected_label
+    assert any(isinstance(a, BraketVerbatim) for a in box.annotations)
+
+
+@pytest.mark.parametrize(
+    "source,qubit_labels,expected_present,expected_absent,expect_unchanged",
+    [
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nqubit[2] q;\nh q[0];\ncnot q[0], q[1];\n",
+            [3, 7],
+            ["$3", "$7"],
+            ["qubit["],
+            False,
+        ),
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nh $0;\ncnot $0, $1;\n",
+            [3, 7],
+            ["$3", "$7"],
+            ["$0;", "$1;"],
+            False,
+        ),
+        (
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n",
+            None,
+            [],
+            [],
+            True,
+        ),
+    ],
+    ids=["virtual_form", "layout_aware_form", "noop_when_none"],
+)
+def test_remap_qubits(
+    source: str,
+    qubit_labels: list[int] | None,
+    expected_present: list[str],
+    expected_absent: list[str],
+    expect_unchanged: bool,
+) -> None:
+    result = _remap_qubits(source, qubit_labels)
+    if expect_unchanged:
+        assert result == source
+    _assert_contents(result, expected_present, expected_absent)
+
+
+def test_remap_qubits_raises_on_label_length_mismatch() -> None:
+    """Length mismatch against a declared virtual register raises ``ValueError``."""
+    source = "OPENQASM 3.0;\nqubit[3] q;\nh q[0];\n"
+    with pytest.raises(
+        ValueError, match=r"qubit_labels length \(2\) does not match .*qubit count \(3\)"
+    ):
+        _remap_qubits(source, [3, 7])
+
+
+def test_remap_qubits_rejects_multiple_quantum_registers() -> None:
+    """Braket doesn't support multi-register circuits; ``_remap_qubits`` raises."""
+    source = "OPENQASM 3.0;\nqubit[2] a;\nqubit[2] bq;\nh a[0];\ncx a[0], bq[1];\n"
+    with pytest.raises(
+        ValueError, match=r"Braket does not support multiple quantum registers.*'a'.*'bq'"
+    ):
+        _remap_qubits(source, [10, 11, 12, 13])
+
+
+def test_remap_qubits_rejects_multiple_registers_without_labels() -> None:
+    """Multi-register rejection fires even when ``qubit_labels`` is not provided."""
+    source = "OPENQASM 3.0;\nqubit[2] a;\nqubit[2] bq;\nh a[0];\n"
+    with pytest.raises(ValueError, match=r"Braket does not support multiple quantum registers"):
+        _remap_qubits(source, None)
+
+
+def test_remap_qubits_layout_aware_out_of_range_raises_value_error() -> None:
+    """Out-of-range ``$N`` in layout-aware source produces a ``ValueError``, not IndexError."""
+    source = "OPENQASM 3.0;\nh $0;\ncnot $0, $5;\n"
+    with pytest.raises(
+        ValueError, match=r"qubit_labels length \(2\) is too short for physical qubit reference \$5"
+    ):
+        _remap_qubits(source, [10, 11])
+
+
+@pytest.mark.parametrize(
+    "source,output_names,expected_present,expected_absent",
+    [
+        (
+            "OPENQASM 3.0;\nbit[2] c;\n@braket_verbatim pragma braket verbatim\nbox {\n  h $0;\n}\n",
+            (),
+            ["#pragma braket verbatim", "box {"],
+            ["@braket_verbatim"],
+        ),
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nbox {\n  h $0;\n}\n",
+            (),
+            ["box {"],
+            ["#pragma braket verbatim", "@braket_verbatim"],
+        ),
+        (
+            "OPENQASM 3.0;\n  box {\n    h $0;\n  }\n",
+            (),
+            ["box {"],
+            ["  "],
+        ),
+        (
+            "OPENQASM 3.0;\nh q[0];\n",
+            (),
+            ["OPENQASM 3.0;", "h q[0];"],
+            ["#pragma"],
+        ),
+        (
+            "OPENQASM 3.0;\ninput float[64] theta;\n",
+            (),
+            ["float theta;"],
+            ["float[64]"],
+        ),
+        (
+            "OPENQASM 3.0;\nbit[2] c;\nbit[1] scratch;\n",
+            ("c",),
+            ["output bit[2] c;", "bit[1] scratch;"],
+            ["output bit[1] scratch;"],
+        ),
+    ],
+    ids=[
+        "annotated_box_gets_pragma",
+        "plain_box_passes_through",
+        "strips_indentation",
+        "noop_without_box",
+        "replaces_float64",
+        "restores_output_declaration",
+    ],
+)
+def test_normalize_formatting(
+    source: str,
+    output_names: tuple[str, ...],
+    expected_present: list[str],
+    expected_absent: list[str],
+) -> None:
+    _assert_contents(_normalize_formatting(source, output_names), expected_present, expected_absent)
+
+
+def test_post_process_oq3() -> None:
+    """The two helpers compose to yield remap + normalize on a single source."""
+    source = "OPENQASM 3.0;\ninput float[64] theta;\nbit[2] c;\nqubit[2] q;\ncnot q[0], q[1];\n"
+    result = _normalize_formatting(_remap_qubits(source, [0, 1]), output_names=("c",))
+    _assert_contents(
+        result,
+        ["cnot $0, $1;", "output bit[2] c;", "float theta;"],
+        ["float[64]", "qubit["],
+    )
+
+
+@pytest.mark.parametrize(
+    "build_circuit,basis_gates,verbatim,qubit_labels,expected_present,expected_absent",
+    [
+        (
+            _build_bell_with_rxx,
+            ["h", "cnot", "xx"],
+            False,
+            [3, 7],
+            ["h $3;", "cnot $3, $7;", "xx(0.5) $3, $7;", "bit[2] b;"],
+            ["cx ", "rxx", "qubit["],
+        ),
+        (
+            _build_bell,
+            ["h", "cnot"],
+            True,
+            [0, 1],
+            ["#pragma braket verbatim", "box {", "h $0;", "cnot $0, $1;"],
+            ["@braket_verbatim", "cx "],
+        ),
+        (
+            _build_plain_box,
+            ["h", "cnot"],
+            False,
+            None,
+            ["box {", "h q[0];", "cnot q[0], q[1];"],
+            ["#pragma braket verbatim", "@braket_verbatim"],
+        ),
+    ],
+    ids=["renames_and_remaps", "verbatim_pragma", "plain_box_preserved"],
+)
+def test_post_process_oq3_end_to_end(
+    build_circuit: Callable,
+    basis_gates: list[str],
+    verbatim: bool,
+    qubit_labels: list[int] | None,
+    expected_present: list[str],
+    expected_absent: list[str],
+) -> None:
+    """End-to-end: qasm3.dumps → remap + normalize produces Braket-compatible output."""
+    source = _dumps_with_passes(build_circuit(), basis_gates=basis_gates, verbatim=verbatim)
+    result = _normalize_formatting(_remap_qubits(source, qubit_labels))
+    _assert_contents(result, expected_present, expected_absent)


### PR DESCRIPTION
Adds string-manipulation helpers that transform the raw output of qasm3.dumps() into Braket-compatible OpenQASM 3.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
