### PR TITLE
test: ruff PT012 violations (pre-existing)

### DIFF
--- a/test/unit_tests/test_adapter.py
+++ b/test/unit_tests/test_adapter.py
@@ -558,13 +558,15 @@ class TestAdapter(TestCase):
             ),
         ):
             to_braket(circuit, {"h, cx"}, True, [[0, 1]], connectivity=[[0, 1]])
-        with pytest.raises(TypeError, match="Multiple values for angle_restrictions"):
-            res = {"rx": {0: {np.pi}}}
-            with pytest.warns(
+        res = {"rx": {0: {np.pi}}}
+        with (
+            pytest.raises(TypeError, match="Multiple values for angle_restrictions"),
+            pytest.warns(
                 DeprecationWarning,
                 match="Passing connectivity as a positional argument is deprecated.",
-            ):
-                to_braket(circuit, {"h, cx"}, True, [[0, 1]], res, angle_restrictions=res)
+            ),
+        ):
+            to_braket(circuit, {"h, cx"}, True, [[0, 1]], res, angle_restrictions=res)
 
     def test_type_error_on_bad_input(self):
         """Tests that to_braket raises a TypeError if its first argument isn't a QuantumCircuit."""

--- a/test/unit_tests/test_adapter_to_qiskit_verbatim.py
+++ b/test/unit_tests/test_adapter_to_qiskit_verbatim.py
@@ -285,9 +285,12 @@ def test_context_marker_errors(markers: list[VerbatimBoxDelimiter | str], error_
     context = _QiskitProgramContext()
     context.add_qubits("q", 2)
 
-    with pytest.raises(ValueError, match=error_match):
+    def add_all_markers() -> None:
         for m in markers:
             context.add_verbatim_marker(m)
+
+    with pytest.raises(ValueError, match=error_match):
+        add_all_markers()
 
 
 def test_unclosed_verbatim_box_circuit_property_error():


### PR DESCRIPTION
ruff 0.16.5 enforces PT012 (pytest-raises-with-multiple-statements), which the project's ruff config picks up under preview mode. Two pre-existing violations on main were surfaced when CI upgraded ruff:

- test_adapter.py: hoist the res dict out of the pytest.raises block and combine pytest.raises with pytest.warns via a parenthesized with statement (matches the pattern used in the neighbouring blocks in the same test method).
- test_adapter_to_qiskit_verbatim.py: extract the marker-adding loop into an inner function so pytest.raises wraps a single call.

No behavior change.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/qiskit-braket-provider/blob/main/README.md) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
