### PR TITLE
fix: query queue position from the task, not a reconstructed batch id

### DIFF
--- a/qiskit_braket_provider/providers/braket_quantum_task.py
+++ b/qiskit_braket_provider/providers/braket_quantum_task.py
@@ -157,7 +157,7 @@ class BraketQuantumTask(JobV1):
                 raise NotImplementedError(
                     "We don't provide queue information for the LocalQuantumTask."
                 )
-            return AwsQuantumTask(self.task_id()).queue_position()
+            return task.queue_position()
         return None
 
     def task_id(self) -> str:

--- a/test/unit_tests/test_braket_quantum_task.py
+++ b/test/unit_tests/test_braket_quantum_task.py
@@ -128,13 +128,40 @@ class TestBraketQuantumTask(TestCase):
             tasks=[mock_aws_quantum_task],
             shots=10,
         )
-        mock_aws_quantum_task.return_value.queue_position.return_value = QuantumTaskQueueInfo(
+        mock_aws_quantum_task.queue_position.return_value = QuantumTaskQueueInfo(
             queue_type=QueueType.NORMAL, queue_position=1, message=None
         )
         task_queue = task.queue_position()
 
-        mock_aws_quantum_task.return_value.queue_position.assert_called_once()
-        mock_aws_quantum_task.assert_called_once_with("arn:aws:braket:::quantum-task/AwesomeId")
+        mock_aws_quantum_task.queue_position.assert_called_once()
+        assert task_queue
+
+    @patch(
+        "qiskit_braket_provider.providers.braket_quantum_task.AwsQuantumTask",
+        spec=AwsQuantumTask,
+    )
+    def test_queue_position_uses_own_task_not_reconstructed_batch_id(
+        self, mock_aws_quantum_task_cls: MagicMock
+    ):
+        """Regression test for a multi-task (batch) job: queue_position() must call
+        each task's own queue_position(), not reconstruct an AwsQuantumTask from the
+        semicolon-joined batch task_id(), which is not a valid single ARN."""
+        task_a = Mock(spec=AwsQuantumTask)
+        task_a.queue_position.return_value = QuantumTaskQueueInfo(
+            queue_type=QueueType.NORMAL, queue_position=1, message=None
+        )
+        task_b = Mock(spec=AwsQuantumTask)
+
+        task = BraketQuantumTask(
+            backend=Mock(spec=BraketAwsBackend),
+            task_id="arn:aws:braket:::quantum-task/A;arn:aws:braket:::quantum-task/B",
+            tasks=[task_a, task_b],
+            shots=10,
+        )
+        task_queue = task.queue_position()
+
+        task_a.queue_position.assert_called_once()
+        mock_aws_quantum_task_cls.assert_not_called()
         assert task_queue
 
     @patch(


### PR DESCRIPTION
`BraketQuantumTask.queue_position()` cannot work for a multi-circuit job. It loops over `self._tasks` but returns `AwsQuantumTask(self.task_id()).queue_position()`, and for a batch `task_id()` is every task ARN joined with `;` (`_TASK_ID_DIVIDER` in `braket_backend.py`). That string is not an ARN, so the reconstructed task's `metadata()` call fails against the service.

The fix uses the task being iterated, which already holds a valid ARN:

```diff
-            return AwsQuantumTask(self.task_id()).queue_position()
+            return task.queue_position()
```

Single-task jobs, program sets and `LocalQuantumTask` are unchanged; the loop still returns on the first task.

`test_queue_position` used one task, where the joined id equals the task's own id, so it asserted the reconstruction and passed. It now asserts the task's own method is called, and a new test covers two tasks. Both fail on unmodified `main` (`Expected 'queue_position' to have been called once. Called 0 times`) and pass with the change; 30/30 after.

Not verified against live Braket; I have no AWS credentials here. The wider suite could not run on this machine because a Windows policy blocks the `numba` DLL, so I ran this file with `numba` stubbed for import only.

Drafted with AI assistance. I read the code path and ran the tests before and after myself.
